### PR TITLE
Add explicit permissions to GitHub Actions workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Added explicit permissions block to the tests.yml GitHub Actions workflow
- Set minimal permissions with `contents: read` only
- Addresses CodeQL security alert about missing workflow permissions

## Security Impact
Without explicit permissions, workflows inherit default permissions which may be overly broad. For repositories created before February 2023, this defaults to read-write access. By explicitly setting `contents: read`, we follow the principle of least privilege.

## Changes
- Added permissions block after the `on:` section in `.github/workflows/tests.yml`
- Workflow now only has read access to repository contents
- No functional changes to the workflow behavior

## Test Plan
- [x] Validated YAML syntax
- [x] Verified workflow only needs read access for its operations
- [ ] Workflow will be tested when PR is created (GitHub Actions will run)

🤖 Generated with [Claude Code](https://claude.ai/code)