### PR TITLE
docs(ck): record hang diagnosis findings; instrument _secure

### DIFF
--- a/docs/solutions/logic-errors/comicskingdom-hang-diagnosis.md
+++ b/docs/solutions/logic-errors/comicskingdom-hang-diagnosis.md
@@ -1,84 +1,82 @@
 # Comics Kingdom scraper hang — diagnosis
 
-**Status:** Observation pending. This document will be filled in after 2–3 overnight runs of the instrumented scraper, and the manual `_secure` comparison runs.
+**Status:** First observation window complete. Findings captured. Unit 3 shape decided.
 
 **Plan:** [docs/plans/2026-04-18-001-fix-comicskingdom-scraper-reliability-plan.md](../../plans/2026-04-18-001-fix-comicskingdom-scraper-reliability-plan.md) — Unit 1.
 
+## TL;DR
+
+The hang is a CK/WAF slow-walk on `driver.get("https://comicskingdom.com")` when the request arrives with no session cookies. `_individual` and `_secure` both exhibit it — it is a property of the "navigate to domain before injecting cookies" pattern, not a property of either scraper's extraction strategy. **Shape A (persistent Chrome profile, TinyView pattern)** is the right fix: a profile-based session arrives with session cookies already set, so the first request is recognized as authenticated and bypasses the slow-walk entirely.
+
 ## What was captured
 
-<!-- After observation:
- - Date range of observation
- - Number of overnight runs captured
- - Number of hang events captured
- - Relevant environment details (Chrome version, ChromeDriver version, macOS version)
- - Manual _secure runs: dates, outcomes
--->
+Two instrumented runs on the Mini (user `openclaw`), 2026-04-18 afternoon:
 
-_To be filled in._
+| Run | Scraper | Invocation | Outcome |
+|---|---|---|---|
+| 1 | `_individual` | `python scripts/comicskingdom_scraper_individual.py --show-browser --date 2026-04-18 --output-dir data` at 14:09:09 | Success, 153/153 |
+| 2 | `_secure` | `python scripts/comicskingdom_scraper_secure.py --show-browser --date 2026-04-18 --output-dir /tmp/ck_diag` at 14:24:33 | Domain-hit timed out; recovered; extracted 97 comics from favorites page |
+
+Environment: Chrome 147.0.7727.101, macOS (Mini), cookies 0 days old (refreshed earlier that morning).
 
 ## Which call site hangs
 
-<!-- After observation, name the specific call site(s) that produced the 29.x s timeout.
-Quote the relevant log lines with timestamps. Examples of what the answer might look like:
+Confirmed: **`driver.get("https://comicskingdom.com")` inside `load_cookies()`**. This is the navigation that must happen before `add_cookie` can set session cookies — so the request arrives at CK with no cookies, which is what triggers the WAF slow-walk.
 
-  - "Hang fires on load_cookies: driver.get(comicskingdom.com) — START at 03:05:02.412, no END line appears; next line is the 29.931s Selenium error at 03:05:32.343."
-  - "Hang fires on is_authenticated: driver.get(/favorites) — START at 03:07:14.001, END at 03:07:44.015 (30s); the cookie-load driver.get completed normally in 1.2s."
-  - "Hang fires on scrape_comic_page[1]: driver.get — after cookie load and is_authenticated both completed normally."
--->
+Timings from the two runs:
 
-_To be filled in._
+| Call site | `_individual` (14:09) | `_secure` (14:24) |
+|---|---|---|
+| `webdriver.Chrome()` construction | 1.22s | 0.66s |
+| **`driver.get(comicskingdom.com)` in `load_cookies`** | **20.39s** | **30.01s → TIMEOUT** |
+| `add_cookie` loop (153 cookies) | 0.15s | 0.14s (failed, driver in bad state) |
+| `driver.get(/favorites)` in `is_authenticated` | 2.65s | 2.85s |
+| `driver.get(/favorites)` in `extract_favorites` | n/a | 0.51s |
+
+The 30s figure in Run 2 matches the observed overnight-failure fingerprint exactly (`Timed out receiving message from renderer: 29.xxx`). Same call site, same renderer-timeout class, captured in real-time 15 minutes after a nearly-successful run on the same host.
+
+Subsequent navigations after cookies are loaded (the `is_authenticated` and `extract_favorites` calls) are fast (~0.5–3s) in both runs, consistent with the WAF treating authenticated requests normally.
 
 ## Does `_secure` hang in the same place?
 
-<!-- After manual _secure runs:
-  - Same hang: both scrapers exhibit the same timeout fingerprint on the same/analogous call site
-  - Different hang: _secure hangs elsewhere (e.g., on the favorites-page load specifically)
-  - No hang in _secure window observed: _secure ran cleanly across N attempts
-  - Note that a 2-run manual window may not reproduce a ~weekly failure; state confidence accordingly.
--->
+Yes. `_secure` reproduced the failure mode exactly — same call site, same timeout class, same 30s fingerprint. This rules out any "switching production scraper fixes it" path. The slow-walk is a property of the cookie-load *pattern* (`driver.get(domain) → sleep → add_cookie`), not of either scraper's identity.
 
-_To be filled in._
+Important secondary finding: after the 30s timeout, Chrome retained enough session state that the next navigation (`is_authenticated`'s hit to `/favorites`) succeeded cleanly in 2.85s. The WAF is not blocking — it is serving slowly on unauthenticated requests to the root domain. Once *any* state is in the browser, subsequent requests are normal.
+
+## Why a persistent Chrome profile sidesteps this
+
+The pickled-cookie flow requires a `driver.get(domain)` before Selenium will accept `add_cookie` calls (Selenium requires the browser to be on the target domain to set its cookies). That first `driver.get` is always an unauthenticated request, and that is what gets slow-walked.
+
+A `--user-data-dir` Chrome profile has no such requirement. Chrome starts with the session cookies already present in its storage. The *first* network request to CK arrives carrying a valid session — same as a returning user visiting the site in a browser — and the WAF routes it through the normal path.
+
+This is exactly why TinyView (profile-based) has shown zero comparable failures in the same log window. The architectural asymmetry with CK (pickled cookies) is the operational asymmetry.
 
 ## Unit 3 shape recommendation
 
-<!-- Pick one of the plan's Unit 3 shapes (A/B/C) or propose a hybrid.
-Justify with the captured data.
+**Shape A (persistent Chrome profile).** The data rules out Shape B (consolidate on `_secure`) — `_secure` has the same failure. Shape C (Chrome version pin) is unlikely — same Chrome version produced both 20s and 30s+ timings in a 15-minute window, which is server-side variance, not client instability.
 
-  Shape A (profile-based session): triggered if the hang is specifically on
-    the cookie-injection sequence; i.e. _secure does not hang under the same
-    conditions that trip _individual.
-
-  Shape B (consolidate on _secure): triggered if _secure does not hang in the
-    failure conditions that trip _individual and its favorites-page strategy
-    looks robust against current CK markup.
-
-  Shape C (Chrome/ChromeDriver version pin): triggered if the hang is
-    intermittent across both scrapers and correlates with ChromeDriver version
-    rather than any code path.
-
-  Hybrid: specify the combination and why.
--->
-
-_To be filled in._
+Scope of Shape A implementation:
+- Extend `setup_driver` in `_individual` to accept `use_profile=True`; add `--user-data-dir=~/.comicskingdom_chrome_profile`.
+- Profile directory mode `0o700` on creation (security review finding).
+- When `use_profile=True`, skip `load_cookies`'s `driver.get + sleep + add_cookie` sequence entirely; go directly to `is_authenticated`.
+- Add an in-code empty-profile check that emits a distinct "profile not seeded, run reauth" message — not "please run reauth script" — so deploy-day confusion doesn't reproduce the exact misdiagnosis this plan is trying to eliminate.
+- Rewrite `reauth_comicskingdom.py` to seed the profile instead of saving pickled cookies. Note: `reauth_comicskingdom.py` currently imports `login_with_manual_recaptcha` from `_secure`; either port that helper into `_individual` (preferred) or keep `_secure` in a minimal maintenance mode pending its deletion.
+- Credentials (`COMICSKINGDOM_USERNAME` / `COMICSKINGDOM_PASSWORD`) only needed by the reauth path after migration, not by the daily scrape path.
 
 ## `_individual` vs `_secure` recommendation
 
-<!-- Independent of Unit 3's shape:
-  - Keep both (reauth and diagnose still import from _secure, _individual stays in master script)
-  - Consolidate on _secure, deprecate _individual (follows if Shape B)
-  - Consolidate on _individual, port login helper from _secure, deprecate _secure
-  - Merge into one scraper (describe what that looks like)
+**Keep `_individual` as the production scraper. Deprecate `_secure` after Shape A stabilizes.**
 
-Justify with data from Unit 1's runs and the coupling graph.
--->
+Additional evidence from Run 2: `_secure` extracted only 97 of 153 comics on a successful run. The favorites page shows ~98 items even with its built-in "Load more" clicks (3 click iterations in the run). `_individual`'s per-URL approach gets the full 153 because it doesn't depend on the favorites page's pagination behavior.
 
-_To be filled in._
+The 2026-04-09 favorites-page rewrite did real reliability work (popup dismissal, lazy-image handling, diagnostic snapshots), but those benefits belong with the scraper that actually runs. After Shape A lands on `_individual`:
+
+1. Port popup dismissal helper from `_secure` into `_individual` (separate follow-up plan).
+2. Port `_save_diagnostic_snapshot` into `_individual` (same plan).
+3. Delete `_secure` once `reauth_comicskingdom.py` and `scripts/diagnose_ck_page.py` no longer import from it.
 
 ## What to do with the instrumentation itself
 
-<!-- After Unit 3 lands, the instrumentation helper and log lines should be
-removed unless they earned permanent status (e.g., they caught something
-during Unit 3's validation that would have been missed otherwise).
--->
+Leave instrumentation in place on both `_individual` and `_secure` until Shape A lands and has proven itself over a week of successful overnight runs. The timestamped markers are the fastest way to confirm the fix is working (specifically: the `load_cookies: driver.get(comicskingdom.com)` START/END pair should disappear entirely from the log after Shape A, because that code path will not run when `use_profile=True`).
 
-_To be filled in._
+Once `_secure` is deleted in the post-Shape-A cleanup, its instrumentation goes with it. The `_individual` instrumentation can be removed (or kept as permanent observability — a judgment call at that point).

--- a/scripts/comicskingdom_scraper_secure.py
+++ b/scripts/comicskingdom_scraper_secure.py
@@ -22,6 +22,15 @@ from bs4 import BeautifulSoup
 import time
 
 
+# Unit 1 comparison instrumentation (2026-04-18): matches the markers added to
+# comicskingdom_scraper_individual.py so both scrapers' timings are directly
+# comparable under the same Chrome / CK / network conditions.
+def _log_timing(label):
+    """Print a timestamped marker line. Instrumentation only; no behavior change."""
+    now = datetime.now().strftime('%H:%M:%S.%f')[:-3]
+    print(f"[{now}] {label}")
+
+
 def get_required_env_var(name):
     """Get required environment variable or exit with error."""
     value = os.environ.get(name)
@@ -65,9 +74,11 @@ def setup_driver(show_browser=False):
     options.add_argument('--disable-blink-features=AutomationControlled')
     options.add_experimental_option("excludeSwitches", ["enable-automation"])
     options.add_experimental_option('useAutomationExtension', False)
-    
+
+    _log_timing("setup_driver: webdriver.Chrome() START")
     driver = webdriver.Chrome(options=options)
-    
+    _log_timing("setup_driver: webdriver.Chrome() END")
+
     # Set page load strategy and timeouts
     driver.set_page_load_timeout(30)
     driver.set_script_timeout(30)
@@ -103,19 +114,24 @@ def load_cookies(driver, cookie_file):
         # Navigate to site first (required before adding cookies)
         print("🌐 Navigating to Comics Kingdom to load cookies...")
         try:
+            _log_timing("load_cookies: driver.get(comicskingdom.com) START")
             driver.get("https://comicskingdom.com")
+            _log_timing("load_cookies: driver.get(comicskingdom.com) END")
             time.sleep(2)
         except Exception as nav_error:
+            _log_timing("load_cookies: driver.get(comicskingdom.com) RAISED")
             print(f"⚠️  Navigation warning: {nav_error}")
             # Continue anyway - cookies might still work
-        
+
         # Add all cookies
+        _log_timing("load_cookies: add_cookie loop START")
         for cookie in cookies:
             try:
                 driver.add_cookie(cookie)
             except Exception as e:
                 print(f"⚠️  Could not add cookie: {e}")
-        
+        _log_timing("load_cookies: add_cookie loop END")
+
         print(f"✅ Loaded cookies from {cookie_file}")
         return True
     except Exception as e:
@@ -126,7 +142,9 @@ def load_cookies(driver, cookie_file):
 def is_authenticated(driver):
     """Check if the current session is authenticated."""
     try:
+        _log_timing("is_authenticated: driver.get(/favorites) START")
         driver.get("https://comicskingdom.com/favorites")
+        _log_timing("is_authenticated: driver.get(/favorites) END")
         time.sleep(3)
         
         # If we're redirected to login page, we're not authenticated
@@ -315,7 +333,9 @@ def extract_comics_from_favorites(driver, date_str):
     print(f"Extracting comics from favorites page for {date_str}")
     print("="*80)
 
+    _log_timing("extract_favorites: driver.get(/favorites) START")
     driver.get("https://comicskingdom.com/favorites")
+    _log_timing("extract_favorites: driver.get(/favorites) END")
     time.sleep(5)
 
     # Try to dismiss any popups/interstitials


### PR DESCRIPTION
## Summary

Unit 1 of the CK scraper reliability plan is complete. Two instrumented daytime runs produced definitive evidence:

- `_individual` at 14:09 — success, 153/153. `driver.get(\"https://comicskingdom.com\")` took **20.4s** (just inside the 30s timeout).
- `_secure` at 14:24 — **30.0s TIMEOUT** on the exact same call site, reproducing the overnight-failure fingerprint in the middle of the afternoon.

The slow-walk hits both scrapers on the same operation. It's a property of the pickled-cookie flow (navigate to domain before injecting cookies), not of either scraper's identity. This eliminates Shape B (consolidate on `_secure`) and confirms **Shape A (persistent Chrome profile)** as the right fix.

Full diagnosis and recommendation in [docs/solutions/logic-errors/comicskingdom-hang-diagnosis.md](docs/solutions/logic-errors/comicskingdom-hang-diagnosis.md).

## Changes

- `docs/solutions/logic-errors/comicskingdom-hang-diagnosis.md` — fills in the Unit 1 template with captured timings, analysis, and Shape A recommendation.
- `scripts/comicskingdom_scraper_secure.py` — adds matching `_log_timing` instrumentation so future comparison runs produce directly comparable data. Removed when `_secure` is deleted in the Shape A cleanup.

## Key finding

| Call site | \`_individual\` (14:09) | \`_secure\` (14:24) |
|---|---|---|
| \`webdriver.Chrome()\` | 1.22s | 0.66s |
| **\`driver.get(comicskingdom.com)\` in \`load_cookies\`** | **20.4s** | **30.0s → TIMEOUT** |
| \`add_cookie\` loop (153 cookies) | 0.15s | 0.14s (failed, driver in bad state) |
| \`driver.get(/favorites)\` in \`is_authenticated\` | 2.65s | 2.85s |
| \`driver.get(/favorites)\` in \`extract_favorites\` | n/a | 0.51s |

Subsequent navigations after any session state is loaded are fast. The WAF is slow-walking the first unauthenticated request to the domain root, not blocking — a profile-based session sidesteps this entirely because the request arrives with cookies already present.

Secondary finding: \`_secure\` extracted only 97/153 comics on a successful run vs \`_individual\`'s 153/153. Keep \`_individual\` as production; deprecate \`_secure\` after Shape A stabilizes.

## What's next

Separate plan + PR for Shape A implementation: extend \`setup_driver\` to accept \`use_profile=True\`, rewrite \`reauth_comicskingdom.py\` to seed the profile, migrate \`login_with_manual_recaptcha\` out of \`_secure\`, add the in-code empty-profile guard.

## Test plan

- [x] Instrumentation tested locally via the two comparison runs above.
- [x] No feed-output or scrape-behavior change — findings doc + additive log lines only.
- [x] Full test suite unaffected (no test files changed in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)