### PR TITLE
chore(testenv): resolve three known-issue items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ config/config.json
 !.env.example
 debug_*.html
 *.log
+# Host-local chromedriver binary (downloaded per-host; see mini_master_update.sh)
+/bin/
 
 # Local test and debug files (not for repo)
 analyze_*.py

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -52,14 +52,12 @@ Stable. Daily automation is healthier than it was 24 hours ago: all six sources 
 
 - GoComics strips don't save to read-later platforms like Pocket/Instapaper (#91) — approach TBD.
 - Old data files (pre-March 31) have fewer entries (~100/day vs 257) than current runs; only ~115 comics matched slugs under the old extraction approach.
-- A handful of tests in `test_comic_config.py`, `test_loader.py`, and `test_web_interface.py` fail at collection time due to a missing `webdriver_manager` dependency in the current venv. Pre-existing and unrelated to the 2026-04-17 work; 229 other tests pass.
-- A couple of tests still produce side-effect writes at the repo root (`feeds/clayjones.xml`, `data/last_update_times.json`) when the suite runs. Worth cleaning up at some point so developers don't have to revert them before committing.
 
 ## Environment & Setup
 <!-- How to run this project. Critical for fresh agent sessions. -->
 
 **Run locally:** `netlify dev` (full stack at `http://localhost:8888`) or `python run_app.py` (Flask at `http://localhost:5001`)
-**Run tests:** `pytest -v` (or `pytest -v --cov=comiccaster --cov-report=term-missing`) — 229 passing, a few pre-existing collection errors (see Known Issues), requires Python ≥3.10
+**Run tests:** `pytest -v` (or `pytest -v --cov=comiccaster --cov-report=term-missing`) — 254 passing, requires Python ≥3.10
 **Deploy:** Push to `main` to trigger Netlify deployment
 **Key env vars:** `FLASK_DEBUG` (local optional), `NODE_VERSION`, `NETLIFY_FUNCTIONS_DIR`
 **Production pipeline:** see [docs/LOCAL_AUTOMATION_README.md](LOCAL_AUTOMATION_README.md) and [docs/DEPLOYMENT.md](DEPLOYMENT.md)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ feedgen==0.9.0
 python-dotenv==1.2.2
 APScheduler==3.11.2
 selenium==4.43.0
+webdriver-manager==4.0.2
 flask==3.1.3
 requests-toolbelt==1.0.0
 pytz==2026.1.post1

--- a/tests/test_feed_content_adjustments.py
+++ b/tests/test_feed_content_adjustments.py
@@ -80,16 +80,16 @@ class TestFeedContentAdjustments:
         assert 'political' in description.lower() or 'editorial' in description.lower()
         assert 'cartoon' in description.lower()
     
-    def test_add_content_warnings(self, political_comic_info, political_feed_entries):
+    def test_add_content_warnings(self, political_comic_info, political_feed_entries, tmp_path):
         """Test adding content warnings for political comics."""
         from comiccaster.feed_generator import ComicFeedGenerator
-        
-        generator = ComicFeedGenerator()
-        
+
+        generator = ComicFeedGenerator(output_dir=str(tmp_path))
+
         # Generate feed with political entries
         success = generator.generate_feed(political_comic_info, political_feed_entries)
         assert success
-        
+
         # Parse generated feed
         feed_path = Path(generator.output_dir) / f"{political_comic_info['slug']}.xml"
         parsed_feed = feedparser.parse(str(feed_path))

--- a/tests/test_smart_update_strategy.py
+++ b/tests/test_smart_update_strategy.py
@@ -201,13 +201,14 @@ class TestSmartUpdateStrategy:
              patch('scripts.update_feeds.load_political_comics_list') as mock_load_political, \
              patch('scripts.update_feeds.load_last_update_times') as mock_load_times, \
              patch('scripts.update_feeds.filter_comics_for_update') as mock_filter, \
+             patch('scripts.update_feeds.save_last_update_times') as mock_save_times, \
              patch('scripts.update_feeds.update_comic_feed') as mock_update:
-            
+
             mock_load_comics.return_value = []
             mock_load_political.return_value = mock_comics
             mock_load_times.return_value = {}
             mock_filter.return_value = [mock_comics[0]]  # Only daily comic needs update
-            
+
             update_feeds_smart()
             
             # Verify only filtered comics were updated


### PR DESCRIPTION
## Summary

Clears all three Known Issues items from `docs/STATUS.md` in one focused cleanup:

1. **`.gitignore`:** Add `/bin/` so the host-local chromedriver binary (downloaded per-host per `mini_master_update.sh`'s PATH setup — `~/bin/`) stays out of the repo. It had been untracked but showing up in `git status` every run.
2. **`requirements.txt`:** Add `webdriver-manager==4.0.2`. `comiccaster/loader.py:23` imports it at module level and `:57` calls `ChromeDriverManager().install()` — so it was already a real runtime dependency, just missing from the manifest. Its absence caused collection errors in `test_comic_config.py`, `test_loader.py`, and `test_web_interface.py` in local venvs. CI installs it separately via `.github/workflows/tests.yml:38`, which is why CI passed.
3. **Test side-effect writes:** Two tests were writing to the repo root on every run:
   - `test_add_content_warnings` constructed `ComicFeedGenerator()` with the default `output_dir="feeds"`, writing `feeds/clayjones.xml`. Fixed by passing `output_dir=str(tmp_path)` — same pattern already used by `test_feed_xml_structure_for_political_comics`.
   - `test_update_feeds_with_smart_scheduling` mocked every `update_feeds` collaborator except `save_last_update_times`, which runs inside `update_feeds_smart()` and wrote `data/last_update_times.json`. Fixed by adding the missing `patch`.

## Not in scope

Tracked historical copies of `feeds/clayjones.xml` and `data/last_update_times.json` (committed by past daily-automation commits) are left in place. The Known-Issues item was about "developers have to revert before committing," which the test fixes alone resolve. Cleanup of the tracked files themselves can happen separately if desired.

## Test plan

- [x] Pre-existing test suite: 240 → 254 passing (+14 unlocked by webdriver-manager install; no regressions)
- [x] Full suite run: no new files appear in `git status` after `pytest -q` (verified by deleting and re-running)
- [x] `git check-ignore bin/` returns a match (ignore rule working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)