### PR TITLE
feat(ops): watch feedback.comiccaster.xyz and open issues for new posts

### DIFF
--- a/.github/workflows/watch-feedback.yml
+++ b/.github/workflows/watch-feedback.yml
@@ -1,0 +1,31 @@
+name: Watch Feedback Site
+
+on:
+  schedule:
+    - cron: '17 14 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install feedparser
+
+      - name: Check feedback feed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python scripts/watch_feedback.py

--- a/scripts/watch_feedback.py
+++ b/scripts/watch_feedback.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Watch the public feedback feed and open issues for new posts.
+
+Idempotent: each post on https://feedback.comiccaster.xyz becomes at most one
+GitHub issue, identified by a "Source: <url>" line in the issue body. Designed
+to run from CI on a schedule; uses the `gh` CLI (pre-installed on runners).
+"""
+
+import json
+import subprocess
+import sys
+
+import feedparser
+
+FEED_URL = "https://feedback.comiccaster.xyz/feed/global.atom"
+LABEL = "feedback-site"
+LABEL_COLOR = "5319e7"
+SOURCE_PREFIX = "Source: "
+
+
+def gh(*args: str) -> str:
+    return subprocess.run(
+        ["gh", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def ensure_label() -> None:
+    existing = json.loads(gh("label", "list", "--json", "name", "--limit", "200"))
+    if any(label["name"] == LABEL for label in existing):
+        return
+    gh(
+        "label", "create", LABEL,
+        "--description", "Reported on feedback.comiccaster.xyz",
+        "--color", LABEL_COLOR,
+    )
+
+
+def known_post_urls() -> set[str]:
+    issues = json.loads(
+        gh(
+            "issue", "list",
+            "--label", LABEL,
+            "--state", "all",
+            "--limit", "500",
+            "--json", "body",
+        )
+    )
+    urls = set()
+    for issue in issues:
+        for line in (issue.get("body") or "").splitlines():
+            if line.startswith(SOURCE_PREFIX):
+                urls.add(line[len(SOURCE_PREFIX):].strip())
+    return urls
+
+
+def open_issue(entry) -> None:
+    title = entry.title.strip()
+    author = getattr(entry, "author", "unknown")
+    published = getattr(entry, "published", getattr(entry, "updated", "unknown"))
+    body = (
+        "New post on the feedback site.\n\n"
+        f"- Title: {title}\n"
+        f"- Author: {author}\n"
+        f"- Published: {published}\n"
+        f"\n{SOURCE_PREFIX}{entry.link}\n"
+    )
+    gh(
+        "issue", "create",
+        "--title", f"[feedback-site] {title}",
+        "--body", body,
+        "--label", LABEL,
+    )
+
+
+def main() -> int:
+    feed = feedparser.parse(FEED_URL)
+    if not feed.entries:
+        if feed.bozo:
+            print(f"feed parse error: {feed.bozo_exception}", file=sys.stderr)
+            return 1
+        print("feed has no entries, nothing to do")
+        return 0
+
+    ensure_label()
+    seen = known_post_urls()
+    new_entries = [e for e in feed.entries if e.link not in seen]
+    print(
+        f"feed entries: {len(feed.entries)}, "
+        f"already tracked: {len(seen)}, new: {len(new_entries)}"
+    )
+    for entry in new_entries:
+        print(f"opening issue: {entry.title}")
+        open_issue(entry)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Adds a daily GitHub Actions workflow (\`watch-feedback.yml\`) that polls https://feedback.comiccaster.xyz/feed/global.atom and opens a labelled issue for each new post, so feedback-site reports flow into the same triage queue as the rest of project work.
- New script \`scripts/watch_feedback.py\` (~75 lines) does the work via the \`gh\` CLI.
- Idempotent without a state file: state lives in the issues themselves (label \`feedback-site\` + a \`Source: <url>\` line in the body — that line is the dedupe key).
- Schedule: \`17 14 * * *\` (daily, off-minute) plus \`workflow_dispatch\` for manual triggering.
- Permissions scoped to \`issues: write\`; \`feedparser\` is the only added dep (already in \`requirements.txt\`, installed standalone in the workflow).

## First run
The first execution will create one issue per existing post on the feedback site (5 today, including the welcome post and items that are already shipped, e.g. the Far Side feed). Close any that don't need ongoing tracking — every subsequent run will only file genuinely new posts.

## Test plan
- [ ] CI passes (workflow YAML lints; \`watch_feedback.py\` parses)
- [ ] After merge, manually trigger via Actions → "Watch Feedback Site" → Run workflow
- [ ] Confirm 5 issues created with label \`feedback-site\`, each containing a \`Source:\` line
- [ ] Trigger a second manual run; confirm 0 new issues (dedupe works)
- [ ] (Optional) Wait for the scheduled fire at 14:17 UTC and confirm it stays at 0 new issues until a real new post lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)