### PR TITLE
fix(security): split CK credentials from cookie_file to clear CodeQL alerts #53 and #54

### DIFF
--- a/scripts/comicskingdom_scraper_individual.py
+++ b/scripts/comicskingdom_scraper_individual.py
@@ -48,9 +48,17 @@ def get_required_env_var(name):
 def load_config_from_env(require_credentials=True):
     """Load configuration from environment variables.
 
-    When require_credentials is False, COMICSKINGDOM_USERNAME and
-    COMICSKINGDOM_PASSWORD may be unset (they land as None). Use
-    require_credentials=False on the daily-scrape path under profile-based
+    Returns (cookie_file, credentials):
+      - cookie_file: Path to the cookie pickle file.
+      - credentials: dict with 'username' and 'password' keys. Values are
+        non-empty strings when require_credentials=True; either may be None
+        when require_credentials=False and the env var is unset.
+
+    Cookie file and credentials are returned as separate values so the path
+    can be passed and printed without touching anything that holds the
+    password.
+
+    Use require_credentials=False on the daily-scrape path under profile-based
     auth, where credentials are not needed. Use require_credentials=True
     (default) for the reauth flow, which does need them.
     """
@@ -61,18 +69,15 @@ def load_config_from_env(require_credentials=True):
         username = os.environ.get('COMICSKINGDOM_USERNAME')
         password = os.environ.get('COMICSKINGDOM_PASSWORD')
 
-    config = {
-        'credentials': {
-            'username': username,
-            'password': password,
-        },
-        'cookie_file': Path(get_optional_env_var('COMICSKINGDOM_COOKIE_FILE', 'data/comicskingdom_cookies.pkl'))
-    }
+    credentials = {'username': username, 'password': password}
+    cookie_file = Path(get_optional_env_var(
+        'COMICSKINGDOM_COOKIE_FILE', 'data/comicskingdom_cookies.pkl'
+    ))
 
-    print(f"✅ Loaded configuration from environment")
-    print(f"   Cookie file: {config['cookie_file']}")
+    print("✅ Loaded configuration from environment")
+    print(f"   Cookie file: {cookie_file}")
 
-    return config
+    return cookie_file, credentials
 
 
 def get_optional_env_var(name, default):
@@ -186,7 +191,7 @@ def is_authenticated(driver):
         return False
 
 
-def authenticate_with_cookies(driver, config, use_profile=False):
+def authenticate_with_cookies(driver, cookie_file, use_profile=False):
     """Authenticate either via a persistent Chrome profile or pickled cookies.
 
     When use_profile is True, Chrome is expected to have launched with
@@ -215,8 +220,6 @@ def authenticate_with_cookies(driver, config, use_profile=False):
 
         print("❌ Authentication failed - please run reauth script")
         return False
-
-    cookie_file = config['cookie_file']
 
     # Check cookie age
     if cookie_file.exists():
@@ -479,7 +482,9 @@ def main():
 
     # Load configuration. Credentials are only required when seeding the
     # profile (reauth). Daily scrape under --use-profile does not need them.
-    config = load_config_from_env(require_credentials=not args.use_profile)
+    cookie_file, _credentials = load_config_from_env(
+        require_credentials=not args.use_profile
+    )
 
     # Load comics catalog
     comics = load_comics_catalog()
@@ -489,7 +494,7 @@ def main():
 
     try:
         # Authenticate
-        if not authenticate_with_cookies(driver, config, use_profile=args.use_profile):
+        if not authenticate_with_cookies(driver, cookie_file, use_profile=args.use_profile):
             print("❌ Authentication failed")
             driver.quit()
             return 1

--- a/scripts/diagnose_ck_page.py
+++ b/scripts/diagnose_ck_page.py
@@ -143,13 +143,13 @@ def main():
     output_dir = Path('data/ck_diagnostics')
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    config = load_config_from_env()
+    cookie_file, _credentials = load_config_from_env()
     driver = setup_driver(show_browser=True)
 
     try:
         # Phase 1: Load cookies and authenticate
         print("\n=== Phase 1: Authentication ===")
-        if not load_cookies(driver, config['cookie_file']):
+        if not load_cookies(driver, cookie_file):
             print("No cookies loaded. Exiting (run reauth first).")
             return 1
 

--- a/tests/test_comicskingdom_scraper.py
+++ b/tests/test_comicskingdom_scraper.py
@@ -99,8 +99,7 @@ class TestAuthenticateWithCookies:
         driver = MagicMock()
         driver.current_url = "https://comicskingdom.com/login"
 
-        config = {"cookie_file": cookie_file}
-        assert cki.authenticate_with_cookies(driver, config) is False
+        assert cki.authenticate_with_cookies(driver, cookie_file) is False
 
         captured = capsys.readouterr()
         assert "Authentication failed - please run reauth script" in captured.out
@@ -113,8 +112,7 @@ class TestAuthenticateWithCookies:
         driver = MagicMock()
         driver.current_url = "https://comicskingdom.com/favorites"
 
-        config = {"cookie_file": cookie_file}
-        assert cki.authenticate_with_cookies(driver, config) is True
+        assert cki.authenticate_with_cookies(driver, cookie_file) is True
 
 
 class TestAuthenticateWithProfile:
@@ -131,7 +129,7 @@ class TestAuthenticateWithProfile:
 
         # Prove load_cookies is not called when use_profile=True
         with patch.object(cki, "load_cookies") as mock_load:
-            result = cki.authenticate_with_cookies(driver, {}, use_profile=True)
+            result = cki.authenticate_with_cookies(driver, None, use_profile=True)
 
         assert result is True
         mock_load.assert_not_called()
@@ -145,7 +143,7 @@ class TestAuthenticateWithProfile:
         driver = MagicMock()
         driver.current_url = "https://comicskingdom.com/login"
 
-        result = cki.authenticate_with_cookies(driver, {}, use_profile=True)
+        result = cki.authenticate_with_cookies(driver, None, use_profile=True)
         assert result is False
 
         captured = capsys.readouterr()
@@ -165,7 +163,7 @@ class TestAuthenticateWithProfile:
         driver = MagicMock()
         driver.current_url = "https://comicskingdom.com/login"
 
-        result = cki.authenticate_with_cookies(driver, {}, use_profile=True)
+        result = cki.authenticate_with_cookies(driver, None, use_profile=True)
         assert result is False
 
         captured = capsys.readouterr()
@@ -181,8 +179,7 @@ class TestAuthenticateWithProfile:
         driver = MagicMock()
         driver.current_url = "https://comicskingdom.com/favorites"
 
-        config = {"cookie_file": cookie_file}
-        assert cki.authenticate_with_cookies(driver, config, use_profile=False) is True
+        assert cki.authenticate_with_cookies(driver, cookie_file, use_profile=False) is True
 
 
 # --- setup_driver -----------------------------------------------------------
@@ -388,9 +385,12 @@ class TestLoadConfigFromEnv:
         monkeypatch.delenv("COMICSKINGDOM_USERNAME", raising=False)
         monkeypatch.delenv("COMICSKINGDOM_PASSWORD", raising=False)
 
-        config = cki.load_config_from_env(require_credentials=False)
-        assert config["credentials"]["username"] is None
-        assert config["credentials"]["password"] is None
+        cookie_file, credentials = cki.load_config_from_env(
+            require_credentials=False
+        )
+        assert credentials["username"] is None
+        assert credentials["password"] is None
+        assert cookie_file is not None
 
     def test_require_credentials_true_still_exits_when_missing(
         self, monkeypatch


### PR DESCRIPTION
## Summary
Closes CodeQL alerts [#53](https://github.com/adamprime/comiccaster/security/code-scanning/53) and [#54](https://github.com/adamprime/comiccaster/security/code-scanning/54) (\`py/clear-text-logging-sensitive-data\`, severity **high**).

## What CodeQL was flagging
Two prints in \`scripts/comicskingdom_scraper_individual.py\` that interpolated the cookie-file path:
- Line 73 — \`print(f"   Cookie file: {config['cookie_file']}")\`
- Line 166 — \`print(f"✅ Loaded cookies from {cookie_file}")\` (where \`cookie_file\` came from \`config['cookie_file']\` at line 219)

CodeQL was correct that **the data flow was concerning**, even though no password actually leaked. The password was being loaded into the same dict as the cookie-file path, so the entire \`config\` dict became tainted in CodeQL's analysis, and every print downstream of it got flagged.

Worth noting: in the current Shape A flow the \`COMICSKINGDOM_PASSWORD\` env var is loaded but never actually consumed — the operator types credentials directly into the manual-reCAPTCHA Chrome login. So this was always a structural false-positive on the print sinks. The colocation in the dict was the real smell.

## Fix
- \`load_config_from_env\` now returns \`(cookie_file, credentials)\` as two separate values instead of a single nested dict.
- \`authenticate_with_cookies\` takes \`cookie_file\` directly instead of the full config dict.
- The cookie-file path is now sourced from a variable that never holds, and never was reachable from, the password — which both clears CodeQL and is a genuine separation of concerns.

## Affected files
- \`scripts/comicskingdom_scraper_individual.py\` — the refactor
- \`scripts/diagnose_ck_page.py\` — only other importer; tuple-unpack at the callsite
- \`tests/test_comicskingdom_scraper.py\` — updated to match new return shape and signature

## Test plan
- [x] \`pytest tests/test_comicskingdom_scraper.py\` — 33 tests pass
- [x] \`pytest\` (full suite) — 276 tests pass
- [ ] CodeQL clears alerts #53 and #54 on this branch's run
- [ ] After merge, re-run the daily CK scrape to confirm runtime behavior unchanged (no signature regressions in the live path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)