### PR TITLE
fix(security): stop loading unused CK credentials from env (closes alert #54)

### DIFF
--- a/scripts/comicskingdom_scraper_individual.py
+++ b/scripts/comicskingdom_scraper_individual.py
@@ -36,53 +36,20 @@ def _log_timing(label):
     print(f"[{now}] {label}")
 
 
-def get_required_env_var(name):
-    """Get required environment variable or exit with error."""
-    value = os.environ.get(name)
-    if not value:
-        print(f"❌ Error: Required environment variable {name} is not set")
-        sys.exit(1)
-    return value
+def load_cookie_file_path():
+    """Return the cookie pickle file path from $COMICSKINGDOM_COOKIE_FILE.
 
-
-def load_config_from_env(require_credentials=True):
-    """Load configuration from environment variables.
-
-    Returns (cookie_file, credentials):
-      - cookie_file: Path to the cookie pickle file.
-      - credentials: dict with 'username' and 'password' keys. Values are
-        non-empty strings when require_credentials=True; either may be None
-        when require_credentials=False and the env var is unset.
-
-    Cookie file and credentials are returned as separate values so the path
-    can be passed and printed without touching anything that holds the
-    password.
-
-    Use require_credentials=False on the daily-scrape path under profile-based
-    auth, where credentials are not needed. Use require_credentials=True
-    (default) for the reauth flow, which does need them.
+    Defaults to data/comicskingdom_cookies.pkl. Under Shape A profile-based
+    auth this is the only piece of configuration the daily scrape needs;
+    credentials are typed by the operator into the browser during reauth
+    (CK's bot check rejects JS-injected fills) and are never read from env.
     """
-    if require_credentials:
-        username = get_required_env_var('COMICSKINGDOM_USERNAME')
-        password = get_required_env_var('COMICSKINGDOM_PASSWORD')
-    else:
-        username = os.environ.get('COMICSKINGDOM_USERNAME')
-        password = os.environ.get('COMICSKINGDOM_PASSWORD')
-
-    credentials = {'username': username, 'password': password}
-    cookie_file = Path(get_optional_env_var(
+    cookie_file = Path(os.environ.get(
         'COMICSKINGDOM_COOKIE_FILE', 'data/comicskingdom_cookies.pkl'
     ))
-
     print("✅ Loaded configuration from environment")
     print(f"   Cookie file: {cookie_file}")
-
-    return cookie_file, credentials
-
-
-def get_optional_env_var(name, default):
-    """Get optional environment variable with default."""
-    return os.environ.get(name, default)
+    return cookie_file
 
 
 def setup_driver(show_browser=False, use_profile=True):
@@ -480,11 +447,7 @@ def main():
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Load configuration. Credentials are only required when seeding the
-    # profile (reauth). Daily scrape under --use-profile does not need them.
-    cookie_file, _credentials = load_config_from_env(
-        require_credentials=not args.use_profile
-    )
+    cookie_file = load_cookie_file_path()
 
     # Load comics catalog
     comics = load_comics_catalog()

--- a/scripts/diagnose_ck_page.py
+++ b/scripts/diagnose_ck_page.py
@@ -14,7 +14,7 @@ from pathlib import Path
 # Reuse auth machinery from the main scraper
 sys.path.insert(0, str(Path(__file__).parent))
 from comicskingdom_scraper_secure import (
-    load_config_from_env, setup_driver, load_cookies, is_authenticated
+    load_cookie_file_path, setup_driver, load_cookies, is_authenticated
 )
 
 
@@ -143,7 +143,7 @@ def main():
     output_dir = Path('data/ck_diagnostics')
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    cookie_file, _credentials = load_config_from_env()
+    cookie_file = load_cookie_file_path()
     driver = setup_driver(show_browser=True)
 
     try:

--- a/tests/test_comicskingdom_scraper.py
+++ b/tests/test_comicskingdom_scraper.py
@@ -362,45 +362,32 @@ class TestLoginWithManualRecaptcha:
         assert not driver.execute_script.called
 
 
-# --- load_config_from_env ---------------------------------------------------
+# --- load_cookie_file_path --------------------------------------------------
 
 
-class TestLoadConfigFromEnv:
-    def test_credentials_not_printed(self, capsys, monkeypatch):
-        monkeypatch.setenv("COMICSKINGDOM_USERNAME", "test-user-do-not-log")
-        monkeypatch.setenv("COMICSKINGDOM_PASSWORD", "test-pass-do-not-log")
-        monkeypatch.setenv(
-            "COMICSKINGDOM_COOKIE_FILE", "data/comicskingdom_cookies.pkl"
+class TestLoadCookieFilePath:
+    def test_uses_env_var_when_set(self, monkeypatch):
+        monkeypatch.setenv("COMICSKINGDOM_COOKIE_FILE", "/tmp/ck-test.pkl")
+        assert str(cki.load_cookie_file_path()) == "/tmp/ck-test.pkl"
+
+    def test_falls_back_to_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("COMICSKINGDOM_COOKIE_FILE", raising=False)
+        assert (
+            str(cki.load_cookie_file_path()) == "data/comicskingdom_cookies.pkl"
         )
 
-        cki.load_config_from_env()
+    def test_does_not_read_credential_env_vars(self, capsys, monkeypatch):
+        # Shape A: credentials are typed by the operator into the browser at
+        # reauth time and are never loaded from env. Setting them here proves
+        # the loader ignores them and they cannot leak into stdout.
+        monkeypatch.setenv("COMICSKINGDOM_USERNAME", "test-user-do-not-log")
+        monkeypatch.setenv("COMICSKINGDOM_PASSWORD", "test-pass-do-not-log")
+
+        cki.load_cookie_file_path()
+
         captured = capsys.readouterr()
         assert "test-user-do-not-log" not in captured.out
         assert "test-pass-do-not-log" not in captured.out
-
-    def test_require_credentials_false_accepts_missing_env_vars(
-        self, monkeypatch
-    ):
-        # Under profile-based auth, credentials aren't needed for daily scrape.
-        monkeypatch.delenv("COMICSKINGDOM_USERNAME", raising=False)
-        monkeypatch.delenv("COMICSKINGDOM_PASSWORD", raising=False)
-
-        cookie_file, credentials = cki.load_config_from_env(
-            require_credentials=False
-        )
-        assert credentials["username"] is None
-        assert credentials["password"] is None
-        assert cookie_file is not None
-
-    def test_require_credentials_true_still_exits_when_missing(
-        self, monkeypatch
-    ):
-        # Reauth path keeps the hard requirement.
-        monkeypatch.delenv("COMICSKINGDOM_USERNAME", raising=False)
-        monkeypatch.delenv("COMICSKINGDOM_PASSWORD", raising=False)
-
-        with pytest.raises(SystemExit):
-            cki.load_config_from_env(require_credentials=True)
 
 
 # --- reauth_comicskingdom.py -------------------------------------------------


### PR DESCRIPTION
## Summary
Closes CodeQL alert [#54](https://github.com/adamprime/comiccaster/security/code-scanning/54) (\`py/clear-text-logging-sensitive-data\`, severity **high**), which remained open after #129 because CodeQL's taint analysis still propagated through the tuple-returning \`load_config_from_env\` even with \`cookie_file\` and \`credentials\` returned as separate elements.

## What changed and why
While planning a more aggressive split (two single-purpose loaders), I traced credential usage and found that **nothing in this codebase actually reads CK credentials any more**:
- \`reauth_comicskingdom.py\` explicitly does *not* load them — line 37: *"Credentials are NOT read from .env — you type them directly into the browser because CK's bot check rejects JS-injected fills."*
- The main scraper unpacked them into \`_credentials\` (a discard variable).
- \`diagnose_ck_page.py\` did the same.

Shape A made credentials an operator concern (typed into the browser at reauth time), but the env-var loader survived the migration as dead code that CodeQL kept flagging.

This PR replaces \`load_config_from_env\` with **\`load_cookie_file_path\`**, which only reads \`COMICSKINGDOM_COOKIE_FILE\`. Drops \`get_required_env_var\` (its only caller was the deleted credential branch). Clears alert #54 the only way that's truly durable: by removing the taint source entirely. You can't leak what you don't load.

## Affected files
- \`scripts/comicskingdom_scraper_individual.py\` — replace loader, drop \`get_required_env_var\`
- \`scripts/diagnose_ck_page.py\` — update import + caller (only other consumer)
- \`tests/test_comicskingdom_scraper.py\` — replace \`TestLoadConfigFromEnv\` with \`TestLoadCookieFilePath\` (3 focused tests: env-var honored, default fallback, credential env vars are ignored)

Net diff: **+30 / -80 lines.**

## Stale docs (follow-up)
References to \`COMICSKINGDOM_USERNAME\` / \`COMICSKINGDOM_PASSWORD\` remain in:
- \`docs/LOCAL_AUTOMATION_README.md\`
- \`docs/setup/COMICSKINGDOM_SETUP.md\`, \`DROPLET_QUICKSTART.md\`, \`DROPLET_SETUP.md\`, \`GITHUB_SECRETS_COMICSKINGDOM.md\`
- \`scripts/SETUP_COMICSKINGDOM_AUTH.sh\`

These now point at env vars no code reads. Out of scope for this security fix; left for a focused doc-cleanup PR. Plan docs under \`docs/plans/\` are point-in-time records and stay as-is.

## Test plan
- [x] \`pytest tests/test_comicskingdom_scraper.py\` — 33/33 pass
- [x] \`pytest\` (full suite) — 276/276 pass
- [ ] CodeQL clears alert #54 on this branch's run
- [ ] After merge, the next daily CK scrape on the local host runs without error (no missing-env-var failures, no signature regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)