### PR TITLE
Auto-resolve ChromeDriver via webdriver-manager

### DIFF
--- a/comiccaster/farside_scraper.py
+++ b/comiccaster/farside_scraper.py
@@ -267,7 +267,8 @@ class FarsideScraper(BaseScraper):
             chrome_options.add_argument('--disable-dev-shm-usage')
             chrome_options.add_argument('--disable-gpu')
             
-            driver = webdriver.Chrome(options=chrome_options)
+            from .webdriver_setup import build_chrome_driver
+            driver = build_chrome_driver(chrome_options)
             
             try:
                 # Start at the New Stuff page

--- a/comiccaster/tinyview_scraper.py
+++ b/comiccaster/tinyview_scraper.py
@@ -21,6 +21,7 @@ from selenium.common.exceptions import TimeoutException
 from bs4 import BeautifulSoup
 
 from .base_scraper import BaseScraper
+from .webdriver_setup import build_chrome_driver
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -61,7 +62,7 @@ class TinyviewScraper(BaseScraper):
                 chrome_options.add_argument('--allow-running-insecure-content')
                 chrome_options.add_argument('--user-agent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36')
                 
-                self.driver = webdriver.Chrome(options=chrome_options)
+                self.driver = build_chrome_driver(chrome_options)
                 self.driver.set_window_size(1920, 1080)
                 self.driver.implicitly_wait(10)
                 self.driver.set_page_load_timeout(30)

--- a/comiccaster/webdriver_setup.py
+++ b/comiccaster/webdriver_setup.py
@@ -1,0 +1,47 @@
+"""Shared Chrome WebDriver setup that auto-resolves a matching ChromeDriver.
+
+Production scrapers historically relied on a manually pinned
+``~/bin/chromedriver`` binary on ``PATH``. That binary broke every time
+Chrome auto-updated past the pinned major version (see incident
+2026-06-09: Chrome 149 vs. ChromeDriver 147 -- took down Comics Kingdom,
+TinyView, and Far Side's New Stuff scrape until the binary was swapped
+by hand).
+
+This helper centralises driver instantiation and defaults to
+``webdriver_manager``, which downloads and caches a ChromeDriver matching
+the installed Chrome on demand. The result is that the next Chrome major
+bump no longer requires manual intervention.
+
+``CHROMEDRIVER_PATH`` remains an emergency override: if it is set, that
+exact binary wins. Useful if webdriver-manager itself ever fails (network
+hiccup, upstream outage) and we need to pin to a known-good driver
+quickly.
+"""
+
+import os
+
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.service import Service
+from webdriver_manager.chrome import ChromeDriverManager
+
+
+def build_chrome_driver(options: Options) -> webdriver.Chrome:
+    """Build a Chrome WebDriver using a driver matched to the installed Chrome.
+
+    Resolution order:
+      1. ``CHROMEDRIVER_PATH`` env var -- emergency override, use that exact binary.
+      2. ``webdriver_manager`` -- download/cache the right driver for the
+         installed Chrome.
+
+    Args:
+        options: Pre-configured ``selenium.webdriver.chrome.options.Options``.
+
+    Returns:
+        An open ``webdriver.Chrome`` instance.
+    """
+    if 'CHROMEDRIVER_PATH' in os.environ:
+        service = Service(executable_path=os.environ['CHROMEDRIVER_PATH'])
+    else:
+        service = Service(ChromeDriverManager().install())
+    return webdriver.Chrome(service=service, options=options)

--- a/scripts/authenticated_scraper_secure.py
+++ b/scripts/authenticated_scraper_secure.py
@@ -17,6 +17,8 @@ from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+
+from comiccaster.webdriver_setup import build_chrome_driver
 from bs4 import BeautifulSoup
 import time
 
@@ -377,7 +379,7 @@ def main():
     options.add_argument('--disable-dev-shm-usage')
     options.add_argument('--window-size=1920,1080')
     
-    driver = webdriver.Chrome(options=options)
+    driver = build_chrome_driver(options)
     
     try:
         # Login (fresh each run - no cookie storage)

--- a/scripts/comicskingdom_scraper_individual.py
+++ b/scripts/comicskingdom_scraper_individual.py
@@ -18,6 +18,8 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from bs4 import BeautifulSoup
+
+from comiccaster.webdriver_setup import build_chrome_driver
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import threading
@@ -85,7 +87,7 @@ def setup_driver(show_browser=False, use_profile=True):
     options.add_experimental_option('useAutomationExtension', False)
 
     _log_timing("setup_driver: webdriver.Chrome() START")
-    driver = webdriver.Chrome(options=options)
+    driver = build_chrome_driver(options)
     _log_timing("setup_driver: webdriver.Chrome() END")
 
     # Set timeouts


### PR DESCRIPTION
## Why

Production scrapers relied on a hand-pinned `~/bin/chromedriver` binary, which broke every time Chrome auto-updated past the pinned major version. On 2026-06-09 Chrome jumped to 149 while the pinned driver was still 147 — silently killed Comics Kingdom, TinyView, and Far Side's New Stuff scrape until the binary was swapped by hand.

## What

New helper `comiccaster/webdriver_setup.build_chrome_driver()`:

- **Default:** `webdriver_manager` downloads and caches a ChromeDriver matching the installed Chrome on demand.
- **Emergency override:** `CHROMEDRIVER_PATH` env var still wins, in case webdriver-manager itself misbehaves and we need to pin to a known-good driver.

Applied at every `webdriver.Chrome()` call site in the production scrapers:

- `scripts/authenticated_scraper_secure.py` (GoComics)
- `scripts/comicskingdom_scraper_individual.py` (Comics Kingdom)
- `comiccaster/tinyview_scraper.py` (TinyView)
- `comiccaster/farside_scraper.py` (Far Side)

(`comiccaster/loader.py` already had an env-toggled version of this; not touched in this PR.)

## Verification

- Full pytest suite: **289 passed**.
- End-to-end smoke test: `build_chrome_driver()` resolved ChromeDriver 149.0.7827.55 to match installed Chrome 149.0.7827.54, opened a session, navigated, quit cleanly.

## Effect

Next Chrome major bump no longer requires manual ChromeDriver replacement. The overnight run self-heals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)