### PR TITLE
Catch-up LaunchAgent safety net for missed overnight runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+Guidance for Claude Code (claude.ai/code) when working in this repository.
+
+ComicCaster's architecture, commands, and the daily feed-update pipeline live in
+`AGENTS.md`, imported just below — this file does not restate them. What follows
+is *how to work here*: the engineering practices to apply on top of those facts.
+(Keep this file and `AGENTS.md` consistent — they're twins: Claude Code / Codex.)
+
+@AGENTS.md
+
+## How we build here
+
+ComicCaster is a real, tested Python + Netlify codebase — not a throwaway script —
+so the practices below apply. Right-size them: a typo or one-line fix doesn't need
+ceremony; a new comic source or a pipeline change does.
+
+### Test-Driven Development
+- Tests are the spec. Write or extend a failing test before the implementation,
+  make it pass, then refactor while green.
+- Run `pytest -v` before every commit (config in `pytest.ini`; coverage is on by
+  default). See Git workflow — `main` ships live, so a green run is the gate.
+- Test behavior at boundaries, not internals: scraper input → `data/<src>_$DATE.json`,
+  generator JSON → `public/feeds/*.xml`, and feed output shape. `tests/` mirrors source.
+- Keep the default run fast and offline. Mock the live comic sources
+  (GoComics, Comics Kingdom, TinyView, New Yorker, Far Side, Creators) — never hit
+  them in unit tests. Use the existing `network` / `integration` pytest markers for
+  the few tests that genuinely need the network.
+
+### SOLID, applied here
+- **OCP is already in the codebase.** `scraper_factory.py` selects a scraper by
+  source. Add a new comic source by registering a scraper in the factory plus a
+  two-phase scrape/generate pair — don't grow an `if/elif` chain.
+- A new source = a new scraper (Phase 1: fetch + parse one source, write
+  `data/<src>_$DATE.json`) and a new generator (Phase 2: network-free, read the
+  latest JSON, write `public/feeds/*.xml`). Mirror the existing pairs exactly.
+- Single responsibility: scrapers fetch + parse one source; feed shaping lives in
+  `feed_generator.py`. Don't blur the two.
+
+### YAGNI
+- Build for the sources and cases that exist today. Don't add config knobs,
+  parameters, or abstraction for a hypothetical next source before it's real — the
+  factory already makes adding one cheap when the time comes.
+
+## Git workflow
+- **Conventional Commits:** `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`,
+  `perf:`, `build:`, `ci:`. The body explains *why*, not what.
+- **Stage explicit paths** — `git add <path1> <path2>`. Never `git add -A` or
+  `git add .`. The pipeline drops dated JSON into `data/` and regenerates many
+  `public/feeds/*.xml`; a blind add sweeps those (and any session-cookie artifacts)
+  into a code commit. Commit code changes and feed-data separately.
+- **`main` auto-deploys to Netlify** — a push is live for RSS subscribers. So:
+  - Run `pytest -v` before you push. A red suite never goes to `main`.
+  - Keep code commits small and reversible.
+  - For risky code changes, route through a branch + PR so the GitHub Action gates
+    it before Netlify ships it. Routine fixes direct to `main` are fine for solo work.
+  - The daily pipeline commits and pushes regenerated feed XML to `main` directly —
+    that's expected automation (see `AGENTS.md`, Phase 3), not something to "fix."
+- `git pull --rebase` before pushing. On a rebase conflict, stop and ask — don't
+  try to be clever.
+- Never `--no-verify` to skip a hook, never force-push shared `main`, never amend a
+  commit that's already been pushed.
+
+## Compound Engineering
+The `compound-engineering` plugin is installed on this account, so its skills are
+available (`ce-plan`, `ce-work`, `ce-code-review`, `ce-debug`, `ce-compound`, …).
+- For non-trivial work (a new source, a pipeline change, anything multi-file):
+  plan → work → review → compound. Skip the ceremony for typos and one-liners.
+- `docs/` already exists here. Capture tricky fixes as
+  `docs/solutions/YYYY-MM-DD-slug.md` and forward-looking work in `docs/plans/`,
+  so the next session — often you, back on this box over Screen Sharing — inherits
+  the context instead of rediscovering it.
+- When you solve something non-obvious (a scraper breaking on a site change, a
+  Netlify build quirk, a re-auth dance), write the solution doc. That payoff is the
+  whole reason to work with this rigor.
+
+## What not to do
+- Don't `git add -A` or `git add .` — stage explicit paths (see Git workflow).
+- Don't hit live comic sources in unit tests — mock them.
+- Don't add a new source with branching logic — register it in `scraper_factory.py`.
+- Don't push code to `main` without a green `pytest -v` first — `main` ships live.
+- Don't commit secrets or session cookies from the authenticated scrapers
+  (Comics Kingdom / TinyView re-auth artifacts). See `SECURITY.md`.

--- a/docs/LOCAL_AUTOMATION_README.md
+++ b/docs/LOCAL_AUTOMATION_README.md
@@ -37,6 +37,7 @@ An earlier hybrid design split scraping between a laptop (one source) and GitHub
 |---|---|
 | `scripts/mini_master_update.sh` | Production entrypoint — sets host-specific environment, execs the tracked master update |
 | `scripts/local_master_update.sh` | Tracked master update — all pipeline logic lives here |
+| `scripts/catchup_master_update.sh` | Login-triggered safety net — runs the master update only if today's GoComics data file is missing |
 | `scripts/scrape_*.py` and per-source authenticated scrapers | Phase 1 scrapers; each writes to `data/*.json` |
 | `scripts/generate_*.py` | Phase 2 generators; each reads `data/*.json` and writes to `public/feeds/*.xml` |
 | `scripts/reauth_comicskingdom.py` | Manual Comics Kingdom session refresh |
@@ -150,6 +151,24 @@ launchctl list | grep comiccaster.master
 launchctl unload ~/Library/LaunchAgents/com.comiccaster.master.plist
 launchctl load   ~/Library/LaunchAgents/com.comiccaster.master.plist
 ```
+
+### Forced overnight macOS updates skipping the 03:05 slot
+
+The master LaunchAgent is user-level (`~/Library/LaunchAgents/...`) and only fires while a user is logged in. A forced macOS update that reboots overnight can leave the host at the loginwindow past 03:05 and the slot is silently skipped (incident 2026-05-26). Two layers of defence:
+
+1. **Stop forced overnight installs.** macOS still notifies; operator installs on demand.
+
+   ```bash
+   sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticallyInstallMacOSUpdates -bool false
+   ```
+
+2. **Catch-up LaunchAgent.** A second user-level agent runs at login and execs the master update only if today's `data/comics_<DATE>.json` is missing. Loaded once on the host:
+
+   ```bash
+   launchctl load -w ~/Library/LaunchAgents/com.comiccaster.catchup.plist
+   ```
+
+   The corresponding script lives in the repo at `scripts/catchup_master_update.sh`.
 
 ### Inspect a failed run
 

--- a/scripts/catchup_master_update.sh
+++ b/scripts/catchup_master_update.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Safety net for the daily ComicCaster pipeline.
+#
+# The primary daily run is driven by ~/Library/LaunchAgents/com.comiccaster.master.plist
+# (StartCalendarInterval 03:05). User-level LaunchAgents only fire while a user
+# session exists, so a forced overnight macOS reboot can leave the host at the
+# loginwindow past 03:05 and the daily run gets silently skipped (see incident
+# 2026-05-26).
+#
+# This script is wired to a *separate* LaunchAgent with RunAtLoad=true so it
+# runs once each time the user logs in (typically once a day, at boot). If
+# today's GoComics data file already exists, it exits cleanly -- no double-run.
+# If not, it execs the production entrypoint to catch up on the missed slot.
+#
+# We use data/comics_<DATE>.json as the canary because GoComics is the first
+# source scraped each day; its presence is a reliable indicator that the
+# primary 03:05 run completed at least Phase 1.
+
+set -eu
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TODAY="$(date +%Y-%m-%d)"
+CANARY="$REPO_DIR/data/comics_$TODAY.json"
+
+if [ -f "$CANARY" ]; then
+    echo "[$(date -Iseconds)] Catch-up: $CANARY present, today's run already happened. Skipping."
+    exit 0
+fi
+
+echo "[$(date -Iseconds)] Catch-up: $CANARY missing. Running master update."
+exec "$REPO_DIR/scripts/mini_master_update.sh"


### PR DESCRIPTION
## Why

The master daily pipeline is driven by `~/Library/LaunchAgents/com.comiccaster.master.plist` at 03:05. User-level LaunchAgents only fire while a user is logged in, so a forced overnight macOS update can leave the host at the loginwindow past 03:05 and the slot is silently skipped. This bit us on **2026-05-26** when macOS Tahoe 26.5 forced an install at 01:12 AM — the LaunchAgent missed its window and no comics shipped until manual recovery in the morning.

## Defence in depth

This PR is the **second** of two layers. Both are documented in `docs/LOCAL_AUTOMATION_README.md`.

### Layer 1 (operator-side, not in this PR)

Turn off macOS's force-install behaviour. macOS still notifies, operator installs on their own schedule:

```bash
sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticallyInstallMacOSUpdates -bool false
```

### Layer 2 (this PR)

New `scripts/catchup_master_update.sh` runs at user login. It checks for `data/comics_<DATE>.json`:
- **Present** → today's run already happened; exit 0.
- **Missing** → exec `mini_master_update.sh` to catch up.

A new `com.comiccaster.catchup` LaunchAgent (lives in `~/Library/LaunchAgents/`, **not** tracked in the repo — matches the existing `master`/`pass2` plist convention) wires it up with `RunAtLoad=true`. Documented in the README's 'Forced overnight macOS updates' section.

## Verification

- Script tested via direct invocation — took the no-op branch correctly because today's `data/comics_2026-06-09.json` is present.
- LaunchAgent loaded on the host (`launchctl list | grep comiccaster` shows all three: master, pass2, catchup).

## What the README now covers

A new troubleshooting section explains the failure mode, both layers of the fix, and the exact `launchctl load` and `sudo defaults write` commands for new hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)