### PR TITLE
fix: harden Far Side proxy (SSRF) + preview feeds from current origin

### DIFF
--- a/functions/proxy-farside-image.js
+++ b/functions/proxy-farside-image.js
@@ -28,16 +28,34 @@ exports.handler = async (event, context) => {
       };
     }
 
-    // Security: Only allow Far Side image URLs
-    const allowedDomains = [
+    // Security: parse the URL and match the hostname EXACTLY. A substring
+    // check (imageUrl.includes('thefarside.com')) is an SSRF bypass — it would
+    // accept thefarside.com.evil.com or evil/?x=thefarside.com.
+    let parsed;
+    try {
+      parsed = new URL(imageUrl);
+    } catch (e) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: 'Invalid url parameter' })
+      };
+    }
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return {
+        statusCode: 403,
+        body: JSON.stringify({ error: 'Disallowed URL scheme' })
+      };
+    }
+
+    const host = parsed.hostname.toLowerCase().replace(/\.$/, '');
+    const allowedHosts = [
       'thefarside.com',
+      'www.thefarside.com',
       'siteassets.thefarside.com',
       'featureassets.amuniversal.com'  // Far Side images are hosted here
     ];
-    
-    const isAllowed = allowedDomains.some(domain => imageUrl.includes(domain));
-    
-    if (!isAllowed) {
+    if (!allowedHosts.includes(host)) {
       console.warn(`Rejected non-Far Side URL: ${imageUrl}`);
       return {
         statusCode: 403,
@@ -45,10 +63,12 @@ exports.handler = async (event, context) => {
       };
     }
 
-    // Fetch the image with proper headers
-    console.log(`Proxying image: ${imageUrl}`);
-    
-    const response = await fetch(imageUrl, {
+    // Fetch the image with proper headers. redirect: 'manual' so a redirect
+    // can't bounce us off an allowed host.
+    console.log(`Proxying image: ${parsed.toString()}`);
+
+    const response = await fetch(parsed.toString(), {
+      redirect: 'manual',
       headers: {
         'Referer': 'https://www.thefarside.com/',
         'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
@@ -63,15 +83,24 @@ exports.handler = async (event, context) => {
       console.error(`Failed to fetch image: ${response.status} ${response.statusText}`);
       return {
         statusCode: response.status,
-        body: JSON.stringify({ 
-          error: `Failed to fetch image: ${response.status} ${response.statusText}` 
+        body: JSON.stringify({
+          error: `Failed to fetch image: ${response.status} ${response.statusText}`
         })
+      };
+    }
+
+    // Only ever serve images back — never relay arbitrary content types.
+    const contentType = response.headers.get('content-type') || 'image/jpeg';
+    if (!contentType.toLowerCase().startsWith('image/')) {
+      console.warn(`Refusing non-image content-type: ${contentType}`);
+      return {
+        statusCode: 415,
+        body: JSON.stringify({ error: 'Upstream did not return an image' })
       };
     }
 
     // Get image data
     const imageBuffer = await response.arrayBuffer();
-    const contentType = response.headers.get('content-type') || 'image/jpeg';
 
     console.log(`Successfully proxied image (${imageBuffer.byteLength} bytes, ${contentType})`);
 

--- a/public/index.html
+++ b/public/index.html
@@ -362,7 +362,13 @@
                     if (!feedUrl) {
                         feedUrl = `https://comiccaster.xyz${feedPath}`;
                     }
-                    
+
+                    // The copied/subscribe URL stays canonical (production), but
+                    // preview from the CURRENT origin so a Netlify deploy preview
+                    // shows that branch's feed instead of the live one. External
+                    // RSS feeds (no local feedPath) preview their own URL.
+                    const previewUrl = feedPath ? `${window.location.origin}${feedPath}` : feedUrl;
+
                     row.innerHTML = `
                         <td>${displayName}</td>
                         <td><a href="${sourceUrl}" target="_blank">🔗 ${sourceName}</a></td>
@@ -372,7 +378,7 @@
                                 <span class="url-text" onclick="copyToClipboard(this)" data-url="${feedUrl}">
                                     ${feedUrl}
                                 </span>
-                                <a href="/preview.html?url=${encodeURIComponent(feedUrl)}" class="preview-link" target="_blank">👁️ Preview</a>
+                                <a href="/preview.html?url=${encodeURIComponent(previewUrl)}" class="preview-link" target="_blank">👁️ Preview</a>
                             </div>
                         </td>
                     `;


### PR DESCRIPTION
Two follow-ups from the Mr. Boffo work (#155).

## 1. Far Side image proxy — SSRF hardening
`functions/proxy-farside-image.js` validated its target with a substring allowlist (`imageUrl.includes('thefarside.com')`), which accepts `thefarside.com.evil.com` or `evil/?x=thefarside.com` — an SSRF bypass. Same weakness I fixed in the Mr. Boffo proxy. Now it:
- parses the URL and matches the **hostname exactly** (`thefarside.com`, `www.thefarside.com`, `siteassets.thefarside.com`, `featureassets.amuniversal.com`),
- rejects non-`http(s)` schemes,
- uses `redirect: 'manual'` so a redirect can't bounce off an allowed host,
- relays only `image/*` responses.

Far Side's required `Referer` header and caching behavior are unchanged.

## 2. Feed Preview reads the wrong feed on deploy previews
The "👁️ Preview" link built its URL from the hardcoded production host (`https://comiccaster.xyz${feedPath}`), so a Netlify **deploy preview always previewed the live feed** — a feed-content change on a branch could never be verified before merge. (This is exactly why the Mr. Boffo image looked broken on the #155 deploy preview even though the fix was correct.)

Now the preview URL is built from `window.location.origin`, so a deploy preview previews **that branch's** feed. The copied/subscribe URL stays canonical production; external-RSS feeds preview their own URL, unchanged.

## Verification
- Full suite green (**321 passed**); `node --check` on the proxy.
- `functions/fetch-feed.js` imposes no host allowlist, so a same-origin preview URL resolves fine.
- After this lands, the Feed Preview page on a deploy preview will reflect branch feeds — verifiable on this PR's own preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)