### PR TITLE
fix: complete the Mr. Boffo HTTPS migration (code missed by #157)

### DIFF
--- a/comiccaster/mrboffo_scraper.py
+++ b/comiccaster/mrboffo_scraper.py
@@ -4,13 +4,17 @@ Mr. Boffo Scraper Module
 Scrapes the Mr. Boffo daily strip (by Joe Martin) for RSS feed generation.
 Uses requests + BeautifulSoup (no authentication required).
 
-Mr. Boffo is self-syndicated via Joe Martin's "Neatly Chiseled Features" and
-runs on its own site at http://www.mrboffo.com/daily.html. The page is a
-hand-built static HTML table (plain HTTP, no HTTPS) that embeds exactly one
-comic image — a single <img> whose src lives under ``images/daily/`` (a legacy
-fixed path the site overwrites in place each day). There is no per-day
-permalink, date metadata, or archive, so the strip is dated by fetch date
-(the same "daily dose" model used by The Far Side).
+Mr. Boffo is self-syndicated via Joe Martin's "Neatly Chiseled Features". We
+source the strip from https://www.mrboffocomics.com/, which embeds exactly one
+comic image (``images/secure_daily.jpg``) — a single fixed path the site
+overwrites in place each day. We use this site rather than mrboffo.com because
+it serves the image over HTTPS, so the feed needs no image proxy (an HTTP image
+would be blocked as mixed content in browsers and web RSS readers).
+
+There is no per-day permalink, date metadata, or archive at any Mr. Boffo site
+(the year-based archives are vintage navigation pages with no harvestable
+strips), so the strip is dated by fetch date — the same "daily dose" model used
+by The Far Side.
 """
 
 import logging
@@ -29,12 +33,12 @@ logger = logging.getLogger(__name__)
 class MrBoffoScraper(BaseScraper):
     """Scraper for the Mr. Boffo daily strip."""
 
-    BASE_URL = "http://www.mrboffo.com"
-    DAILY_URL = "http://www.mrboffo.com/daily.html"
+    BASE_URL = "https://www.mrboffocomics.com"
+    DAILY_URL = "https://www.mrboffocomics.com/"
 
-    # The daily strip image lives under this path fragment; decorative buttons
-    # and headers live under images/buttons/ and images/<other> instead.
-    IMAGE_PATH_MARKER = "images/daily/"
+    # The daily strip is the only image on the page, served over HTTPS at this
+    # fixed path (overwritten daily).
+    IMAGE_PATH_MARKER = "secure_daily"
 
     def __init__(self, timeout: int = 30, max_retries: int = 3):
         """Initialize the Mr. Boffo scraper.

--- a/public/comics_list.json
+++ b/public/comics_list.json
@@ -4183,7 +4183,7 @@
     "name": "Mr. Boffo",
     "slug": "mr-boffo",
     "author": "Joe Martin",
-    "url": "http://www.mrboffo.com/",
+    "url": "https://www.mrboffocomics.com/",
     "source": "mrboffo",
     "position": 570,
     "is_updated": true

--- a/public/index.html
+++ b/public/index.html
@@ -347,7 +347,7 @@
                         feedPath = `/feeds/${comic.slug}.xml`;
                     } else if (comic.source === 'mrboffo') {
                         sourceName = 'Mr. Boffo';
-                        sourceUrl = comic.url || 'http://www.mrboffo.com/';
+                        sourceUrl = comic.url || 'https://www.mrboffocomics.com/';
                         feedPath = `/feeds/${comic.slug}.xml`;
                     } else if (comic.source === 'external-rss') {
                         sourceName = 'Website';

--- a/scripts/generate_mrboffo_feeds.py
+++ b/scripts/generate_mrboffo_feeds.py
@@ -21,7 +21,6 @@ import re
 import sys
 from datetime import datetime
 from pathlib import Path
-from urllib.parse import quote
 
 import pytz
 
@@ -39,16 +38,12 @@ COMIC_INFO = {
     'name': 'Mr. Boffo',
     'slug': 'mr-boffo',
     'author': 'Joe Martin',
-    'url': 'http://www.mrboffo.com/',
+    'url': 'https://www.mrboffocomics.com/',
     'source': 'mrboffo',
 }
 
 DATA_DIR = Path('data')
 OUTPUT_DIR = 'public/feeds'
-# mrboffo.com is HTTP-only, so its image is mixed content on our HTTPS site and
-# gets blocked by browsers and web RSS readers. Route it through our Netlify
-# proxy (mirrors The Far Side) so the image is served over HTTPS.
-IMAGE_PROXY_BASE = 'https://comiccaster.xyz/.netlify/functions/proxy-mrboffo-image'
 # The site serves exactly one strip at a single fixed image path that it
 # overwrites in place each day — there is no archive and no per-day image URL.
 # So the feed only ever holds the current strip: a wider window would emit
@@ -116,19 +111,17 @@ def build_entries(snapshots):
             except ValueError:
                 pub_datetime = datetime.now(eastern)
 
-            # The image path is fixed and overwritten daily, so a reader that
-            # cached it yesterday would show a stale strip. A date-keyed query
-            # forces a fresh fetch for each day's entry (the server serves the
-            # current bytes regardless of the query string).
+            # The image is served over HTTPS at a fixed path that is overwritten
+            # daily, so a reader that cached it yesterday would show a stale
+            # strip. A date-keyed query forces a fresh fetch for each day's
+            # entry (the server serves the current bytes regardless of the query
+            # string).
             cache_busted_url = f"{image_url}?d={target_date}"
-            # Serve the HTTP-only source image over HTTPS via our proxy so it
-            # isn't blocked as mixed content in browsers and web readers.
-            proxied_url = f"{IMAGE_PROXY_BASE}?url={quote(cache_busted_url, safe='')}"
 
             entries.append({
                 'title': f"Mr. Boffo - {target_date}",
                 'url': comic.get('url', COMIC_INFO['url']),
-                'image_url': proxied_url,
+                'image_url': cache_busted_url,
                 'pub_date': pub_datetime,
                 # Plain text — ComicFeedGenerator wraps the description in <p>.
                 'description': f'Mr. Boffo by Joe Martin — {target_date}',

--- a/tests/test_mrboffo_generator.py
+++ b/tests/test_mrboffo_generator.py
@@ -20,9 +20,9 @@ _SPEC.loader.exec_module(gen)
 
 def _comic(**overrides):
     base = {
-        'image_url': 'http://www.mrboffo.com/images/daily/2026/today.jpg',
+        'image_url': 'https://www.mrboffocomics.com/images/secure_daily.jpg',
         'title': 'Mr. Boffo',
-        'url': 'http://www.mrboffo.com/daily.html',
+        'url': 'https://www.mrboffocomics.com/',
     }
     base.update(overrides)
     return base
@@ -37,17 +37,16 @@ class TestBuildEntries:
         assert '2026-06-20' in e['description']
         assert e['id'] == 'mrboffo-2026-06-20'
 
-    def test_image_url_is_https_proxied_with_cache_buster(self):
-        """HTTP-only source image is routed through the HTTPS proxy, and the
-        proxied (inner) URL carries the date cache-buster."""
-        from urllib.parse import quote
+    def test_image_url_is_direct_https_with_cache_buster(self):
+        """The source image is already HTTPS (mrboffocomics.com), so it is
+        embedded directly — no proxy — with a date cache-buster."""
         entries = gen.build_entries([('2026-06-20', [_comic()])])
         url = entries[0]['image_url']
-        # Served over HTTPS via our proxy (fixes mixed-content blocking).
-        assert url.startswith('https://comiccaster.xyz/.netlify/functions/proxy-mrboffo-image?url=')
-        # The original HTTP image URL + date cache-buster is the encoded payload.
-        inner = 'http://www.mrboffo.com/images/daily/2026/today.jpg?d=2026-06-20'
-        assert quote(inner, safe='') in url
+        assert url == (
+            'https://www.mrboffocomics.com/images/secure_daily.jpg?d=2026-06-20'
+        )
+        # No proxy indirection anymore.
+        assert 'proxy-mrboffo-image' not in url
 
     def test_feed_window_is_one(self):
         """Source has no archive; the feed only ever holds the current strip."""

--- a/tests/test_mrboffo_scraper.py
+++ b/tests/test_mrboffo_scraper.py
@@ -7,18 +7,14 @@ these tests never hit mrboffo.com.
 from unittest.mock import patch
 
 
-# A trimmed but faithful slice of mrboffo.com/daily.html: decorative button and
-# header images plus the single daily strip image under images/daily/.
+# A faithful slice of mrboffocomics.com: a single daily strip image served over
+# HTTPS at the fixed secure_daily.jpg path.
 DAILY_HTML = '''
 <html>
   <body>
-    <table>
-      <tr><td><img src="images/jmcomics.jpg" width="435" height="82"></td></tr>
-      <tr><td><img src="images/buttons/boffo.jpg" alt="Mister Boffo Daily"></td></tr>
-      <tr><td><img src="images/topline.gif"></td></tr>
-      <tr><td><img border="0" src="images/daily/1987/011487.jpg"></td></tr>
-      <tr><td><img src="images/Archives-Link.gif"></td></tr>
-    </table>
+    <a href="https://www.mrboffocomics.com/images/secure_daily.jpg">
+      <img src="https://www.mrboffocomics.com/images/secure_daily.jpg" alt="daily">
+    </a>
   </body>
 </html>
 '''
@@ -43,22 +39,22 @@ class TestExtractImages:
         images = scraper.extract_images(DAILY_HTML)
 
         assert len(images) == 1
-        assert images[0]['url'] == 'http://www.mrboffo.com/images/daily/1987/011487.jpg'
+        assert images[0]['url'] == 'https://www.mrboffocomics.com/images/secure_daily.jpg'
 
     def test_absolutizes_relative_image_url(self):
         from comiccaster.mrboffo_scraper import MrBoffoScraper
 
-        html = '<img src="images/daily/2026/today.jpg">'
+        html = '<img src="images/secure_daily.jpg">'
         images = MrBoffoScraper().extract_images(html)
 
-        assert images[0]['url'].startswith('http://www.mrboffo.com/images/daily/')
+        assert images[0]['url'] == 'https://www.mrboffocomics.com/images/secure_daily.jpg'
 
     def test_ignores_decorative_images(self):
         from comiccaster.mrboffo_scraper import MrBoffoScraper
 
         html = '''
-        <img src="images/buttons/boffo.jpg" alt="button">
-        <img src="images/topline.gif">
+        <img src="images/header.gif" alt="banner">
+        <img src="images/misterboffo.gif">
         '''
         assert MrBoffoScraper().extract_images(html) == []
 
@@ -71,7 +67,7 @@ class TestExtractImages:
     def test_image_alt_defaults_to_comic_name(self):
         from comiccaster.mrboffo_scraper import MrBoffoScraper
 
-        html = '<img src="images/daily/x.jpg">'
+        html = '<img src="images/secure_daily.jpg">'
         images = MrBoffoScraper().extract_images(html)
         assert images[0]['alt'] == 'Mr. Boffo'
 
@@ -89,7 +85,7 @@ class TestScrapeComic:
         assert result['image_count'] == len(result['images'])
         assert result['image_count'] == 1
         # Single-image convenience field (from BaseScraper.build_comic_result).
-        assert result['image_url'] == 'http://www.mrboffo.com/images/daily/1987/011487.jpg'
+        assert result['image_url'] == 'https://www.mrboffocomics.com/images/secure_daily.jpg'
         assert result['url'] == MrBoffoScraper.DAILY_URL
 
     def test_returns_none_when_fetch_fails(self):
@@ -109,13 +105,13 @@ class TestScrapeComic:
             assert scraper.scrape_comic() is None
 
     def test_multiple_daily_images_uses_first_and_warns(self, caplog):
-        """If the layout ever exposes 2+ images/daily/ imgs, warn but publish first."""
+        """If the layout ever exposes 2+ secure_daily imgs, warn but publish first."""
         from comiccaster.mrboffo_scraper import MrBoffoScraper
 
         scraper = MrBoffoScraper()
         two = '''
-        <img src="images/daily/2026/first.jpg">
-        <img src="images/daily/2026/second.jpg">
+        <img src="https://www.mrboffocomics.com/images/secure_daily.jpg">
+        <img src="https://www.mrboffocomics.com/images/secure_daily_alt.jpg">
         '''
         with patch.object(scraper, 'fetch_comic_page', return_value=two):
             import logging
@@ -124,5 +120,5 @@ class TestScrapeComic:
 
         assert result is not None
         # The scrape driver publishes images[0]; assert the first match wins.
-        assert result['images'][0]['url'] == 'http://www.mrboffo.com/images/daily/2026/first.jpg'
+        assert result['images'][0]['url'] == 'https://www.mrboffocomics.com/images/secure_daily.jpg'
         assert any('found 2' in r.message for r in caplog.records)


### PR DESCRIPTION
## What happened
#157 was meant to migrate Mr. Boffo to the HTTPS source and remove the image proxy. A bad `git add` on my side (it included a path already removed by `git rm`, so the command staged nothing) meant the **code edits never made it into the squash**. origin/main was left **half-migrated**:
- ✅ proxy function deleted, feed XML already HTTPS-direct (so production renders fine right now)
- ❌ generator still builds `proxy-mrboffo-image` URLs (pointing at the deleted function), scraper still targets HTTP `mrboffo.com`, catalog URL still HTTP, tests still the old fixtures

The latent risk: the **next nightly regen** would rebuild the feed with proxy URLs → broken images again.

## This PR
Lands the missing edits so the whole path is consistently `mrboffocomics.com` over HTTPS, no proxy:
- `MrBoffoScraper` sources `https://www.mrboffocomics.com/` (`secure_daily` marker)
- generator embeds the HTTPS image directly; `IMAGE_PROXY_BASE` removed
- catalog/source URLs HTTPS
- tests updated to HTTPS fixtures

Feed XML unchanged (origin/main's is already correct; regen differs only by the build timestamp).

## Verification
- Full suite green (**321 passed**) — now internally consistent (new code + new tests).
- Confirmed no remaining `proxy-mrboffo` references outside the test that asserts its absence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)