### PR TITLE
docs: register Mr. Boffo source + compound learnings + CONCEPTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI coding assistants when working with this repos
 
 ## Project Overview
 
-ComicCaster generates RSS feeds for comics from multiple sources (GoComics, Comics Kingdom, TinyView, The Far Side). It uses a hybrid serverless/static site architecture deployed on Netlify, with daily automated feed updates run locally.
+ComicCaster generates RSS feeds for comics from multiple sources (GoComics, Comics Kingdom, TinyView, The Far Side, The New Yorker, Creators Syndicate, Mr. Boffo). It uses a hybrid serverless/static site architecture deployed on Netlify, with daily automated feed updates run locally.
 
 ## Key Commands
 
@@ -35,6 +35,7 @@ python scripts/tinyview_scraper_local_authenticated.py # TinyView
 python scripts/scrape_newyorker.py                     # New Yorker
 python scripts/scrape_farside.py                       # Far Side
 python scripts/scrape_creators.py                      # Creators Syndicate
+python scripts/scrape_mrboffo.py                       # Mr. Boffo
 
 # Individual source generators (Phase 2 — reads JSON, writes public/feeds/*.xml; network-free)
 python scripts/generate_gocomics_feeds.py
@@ -43,6 +44,7 @@ python scripts/generate_tinyview_feeds_from_data.py
 python scripts/generate_newyorker_feeds.py
 python scripts/generate_farside_feeds.py
 python scripts/generate_creators_feeds.py
+python scripts/generate_mrboffo_feeds.py
 ```
 
 ## Architecture
@@ -80,7 +82,7 @@ python scripts/generate_creators_feeds.py
 ### Feed Update Process
 
 Daily updates run on a dedicated always-on host, overnight:
-1. **Phase 1 — scrape** the six sources (GoComics, Comics Kingdom, TinyView, New Yorker, Far Side, Creators Syndicate), each writing to `data/<src>_$DATE.json`.
+1. **Phase 1 — scrape** the seven sources (GoComics, Comics Kingdom, TinyView, New Yorker, Far Side, Creators Syndicate, Mr. Boffo), each writing to `data/<src>_$DATE.json`.
 2. **Phase 2 — generate** feeds from those JSONs. Each source has a dedicated generator; all are network-free.
 3. **Invariant guard:** every successful scrape must have written its dated JSON file; missing files surface as failures.
 4. **Phase 3 — commit and push.** On push rejection, recovery saves today's JSONs, resets to `origin/main`, restores them, and regenerates all feeds. Netlify auto-deploys on push.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ ceremony; a new comic source or a pipeline change does.
 - Test behavior at boundaries, not internals: scraper input → `data/<src>_$DATE.json`,
   generator JSON → `public/feeds/*.xml`, and feed output shape. `tests/` mirrors source.
 - Keep the default run fast and offline. Mock the live comic sources
-  (GoComics, Comics Kingdom, TinyView, New Yorker, Far Side, Creators) — never hit
+  (GoComics, Comics Kingdom, TinyView, New Yorker, Far Side, Creators, Mr. Boffo) — never hit
   them in unit tests. Use the existing `network` / `integration` pytest markers for
   the few tests that genuinely need the network.
 
@@ -66,10 +66,17 @@ The `compound-engineering` plugin is installed on this account, so its skills ar
 available (`ce-plan`, `ce-work`, `ce-code-review`, `ce-debug`, `ce-compound`, …).
 - For non-trivial work (a new source, a pipeline change, anything multi-file):
   plan → work → review → compound. Skip the ceremony for typos and one-liners.
-- `docs/` already exists here. Capture tricky fixes as
-  `docs/solutions/YYYY-MM-DD-slug.md` and forward-looking work in `docs/plans/`,
+- `docs/` already exists here. Capture tricky fixes under
+  `docs/solutions/<category>/<slug>.md` and forward-looking work in `docs/plans/`,
   so the next session — often you, back on this box over Screen Sharing — inherits
   the context instead of rediscovering it.
+- `docs/solutions/` is a searchable knowledge store of past solutions (bugs, best
+  practices, workflow patterns), organized by category with YAML frontmatter
+  (`module`, `tags`, `problem_type`) — relevant to grep when implementing or
+  debugging in a documented area.
+- `CONCEPTS.md` (repo root) holds the project's shared domain vocabulary — Sources,
+  the scrape/generate pipeline, feed-shaping terms — relevant when orienting or
+  discussing domain concepts.
 - When you solve something non-obvious (a scraper breaking on a site change, a
   Netlify build quirk, a re-auth dance), write the solution doc. That payoff is the
   whole reason to work with this rigor.

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -1,0 +1,35 @@
+# Concepts
+
+Shared domain vocabulary for this project — entities, named processes, and status concepts with project-specific meaning. Seeded with core domain vocabulary, then accretes as ce-compound and ce-compound-refresh process learnings; direct edits are fine. Glossary only, not a spec or catch-all.
+
+## Sources
+
+### Source
+A comic provider ComicCaster pulls strips from. Each comic carries a `source` tag (e.g. GoComics, Comics Kingdom, TinyView, The Far Side, The New Yorker, Creators Syndicate, Mr. Boffo) that selects how it is fetched and where its feed link points.
+
+### Self-hosted-feed source
+A Source that ComicCaster scrapes itself and whose RSS feed ComicCaster generates and hosts (the feed lives at `/feeds/<slug>.xml`). Most sources are this kind. Contrast with an External-RSS source.
+
+### External-RSS source
+A Source that already publishes its own native RSS feed; ComicCaster simply points subscribers at that publisher feed URL and runs no scrape/generate pipeline for it.
+
+## Pipeline
+
+### Scrape phase
+The network-facing first phase of the daily update: each source is fetched and parsed, writing a dated JSON snapshot per source. The only phase that touches the live comic sites.
+
+### Generate phase
+The network-free second phase: each source's generator reads its latest scraped JSON and writes the feed XML. Safe to re-run during recovery because it never hits the network.
+
+### Invariant guard
+The check between the Generate phase and the commit/push phase that asserts every scrape which reported success actually wrote its dated JSON snapshot; a missing file is surfaced as a failure rather than silently shipping a stale feed.
+
+## Feed shaping
+
+### Daily Dose
+A dating model for sources that have no per-day permalink: the day's strip selection is made upstream by the publisher, and ComicCaster records it dated by fetch date rather than by the strip's own publication date. Used by The Far Side and Mr. Boffo.
+
+A source whose image lives at a single fixed path overwritten in place each day has no retrievable history, so its feed holds only the current strip (a Feed window of one) and relies on fetch-date identity to give each day a distinct entry.
+
+### Feed window
+The number of recent days of strips a generated feed includes. Bounded by what the source's archive can actually serve: a source with distinct per-strip URLs supports a multi-day window, while a single-overwritten-image source supports a window of one.

--- a/docs/LOCAL_AUTOMATION_README.md
+++ b/docs/LOCAL_AUTOMATION_README.md
@@ -10,9 +10,9 @@ An earlier hybrid design split scraping between a laptop (one source) and GitHub
 ┌────────────────────────────────────────────────────────────────┐
 │  Local host, daily overnight run (LaunchAgent)                 │
 │                                                                │
-│  Phase 1 — scrape 6 sources (sequential, fail-soft)            │
+│  Phase 1 — scrape 7 sources (sequential, fail-soft)            │
 │    GoComics, Comics Kingdom, TinyView, Far Side,               │
-│    New Yorker, Creators Syndicate                              │
+│    New Yorker, Creators Syndicate, Mr. Boffo                   │
 │                                                                │
 │  Phase 2 — generate feeds from scraped JSON                    │
 │    one script per source, all network-free                     │

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,8 +1,8 @@
 # Project Status
-<!-- Updated: 2026-05-16 by Codex -->
+<!-- Updated: 2026-06-20 by Claude Code -->
 
 ## Project Overview
-ComicCaster aggregates comics from GoComics, Comics Kingdom, TinyView, The Far Side, The New Yorker, Creators Syndicate, and first-party external RSS feeds into standards-compliant RSS feeds and OPML bundles. A Python pipeline handles scraping and feed generation where ComicCaster owns the feed; external RSS entries link directly to publisher-provided feeds. Netlify serves the static site and feed files.
+ComicCaster aggregates comics from GoComics, Comics Kingdom, TinyView, The Far Side, The New Yorker, Creators Syndicate, Mr. Boffo, and first-party external RSS feeds into standards-compliant RSS feeds and OPML bundles. A Python pipeline handles scraping and feed generation where ComicCaster owns the feed; external RSS entries link directly to publisher-provided feeds. Netlify serves the static site and feed files.
 
 ## Current State
 Stable. Shape A (CK profile-based auth) has been on prod since 2026-04-20 with no observed regressions; daily runs report all-success on most days, with the expected weekly CK session refresh handled manually via `reauth_comicskingdom.py`. PR #139 is open from `codex/external-rss-catalog` to add a separate External RSS catalog and OPML flow for first-party publisher feeds. It avoids the scrape/generate pipeline entirely and should be validated through CI plus the Netlify preview before merge.
@@ -15,14 +15,14 @@ Stable. Shape A (CK profile-based auth) has been on prod since 2026-04-20 with n
 <!-- Features/systems that are shipped and stable. Keep this current. -->
 
 - Daily multi-source RSS feed generation and publishing workflow
-- All six sources use a uniform scrape-to-data / generate-from-data architecture (`scripts/scrape_*.py` → `data/<src>_$DATE.json` → `scripts/generate_*.py` → `public/feeds/*.xml`)
+- All seven sources use a uniform scrape-to-data / generate-from-data architecture (`scripts/scrape_*.py` → `data/<src>_$DATE.json` → `scripts/generate_*.py` → `public/feeds/*.xml`)
 - Production entrypoint is tracked in git (`scripts/mini_master_update.sh`) — no more untracked wrappers patching the master script at runtime
 - Push-conflict recovery uses save / fetch / reset / regenerate (no `git pull --rebase` against generated XMLs)
 - Invariant guard between Phase 2 and Phase 3 catches silent scrape regressions (scrape reports success but its dated JSON is missing)
 - Comics Kingdom authentication uses a persistent Chrome profile at `~/.comicskingdom_chrome_profile` (Shape A); `reauth_comicskingdom.py` is the operator entry point for refresh
 - Chrome boundary instrumentation in `_individual` — timestamped log lines at every `driver.get` make hang-site localization a grep
 - 289-test suite passing across Python 3.10 / 3.11 / 3.12 after PR #139 and #140 merge (281 on `codex/external-rss-catalog` alone + 8 more from `feat/two-pass-scrape-and-catalog-fix`)
-- 312 GoComics feeds, ~153 Comics Kingdom feeds, TinyView feeds, Far Side Daily Dose + New Stuff, New Yorker Daily Cartoon, and 10 Creators feeds updating daily
+- 312 GoComics feeds, ~153 Comics Kingdom feeds, TinyView feeds, Far Side Daily Dose + New Stuff, New Yorker Daily Cartoon, 10 Creators feeds, and Mr. Boffo (single daily strip) updating daily
 - Static site + Netlify functions deployment flow
 - Security policy and private vulnerability reporting enabled; **zero open CodeQL alerts**
 - Consistent comic strip sizing (max-width: 700px) and centering across all sources (#105)

--- a/docs/solutions/best-practices/mixed-content-and-single-image-comic-sources.md
+++ b/docs/solutions/best-practices/mixed-content-and-single-image-comic-sources.md
@@ -1,0 +1,144 @@
+---
+title: Adding a self-hosted comic source — image hosting, feed shape, and proxy safety
+date: 2026-06-20
+category: best-practices
+module: comic-sources
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - "Adding a comic source hosted on the artist's own site rather than a syndication CDN"
+  - "A source serves its image over plain HTTP, or you're about to add a proxy to force HTTPS"
+  - "A source has no archive: one image at a fixed path overwritten in place each day"
+  - "Writing or reviewing a Netlify image proxy (or any server-side fetch of a caller-supplied URL)"
+  - "Images render in a native RSS app but are blank in a web reader"
+tags:
+  - mixed-content
+  - https
+  - image-proxy
+  - ssrf
+  - rss-feed
+  - feed-window
+  - netlify-functions
+  - comic-source
+---
+
+# Adding a self-hosted comic source — image hosting, feed shape, and proxy safety
+
+## Context
+
+ComicCaster adds sources as scraper/generator pairs (Phase 1 fetch → `data/<src>_$DATE.json`; Phase 2 network-free → `public/feeds/*.xml`). Most existing sources (GoComics, Comics Kingdom, Far Side) come with HTTPS image CDNs, dated metadata, and **distinct per-strip image URLs**. A *self-syndicated* comic hosted on the artist's own small site breaks all three assumptions at once.
+
+Adding **Mr. Boffo** (issue #153) surfaced three decisions that recur for any such source — *where the image is hosted, what shape the feed can take, and how to safely reach a non-HTTPS asset*. They constrain each other, so solve them in order: hosting first (a reuse-vs-build decision), then feed shape, then — only on the residue — proxy safety.
+
+## Guidance
+
+### 1. Prefer an existing publisher HTTPS URL over running your own service
+
+The reflex on hitting an HTTP-only image is to write a proxy that re-serves it over HTTPS. Resist it. Resolution order:
+
+1. **Look for a sibling HTTPS host first.** Mr. Boffo is reachable at both `mrboffo.com` (HTTP image) and `mrboffocomics.com` (HTTPS image, same daily strip). Sourcing from `mrboffocomics.com` made the mixed-content problem vanish with zero infrastructure — no function, no SSRF surface, no cold-start, no egress.
+2. **Only if no HTTPS source exists, add a proxy** — and accept that you now operate a network service with its own threat model (§3).
+
+A self-hosted proxy is a liability you operate; a publisher's HTTPS URL is hosting you get for free. Reuse beats build.
+
+**Catch the mixed-content failure correctly — it doesn't fail uniformly:**
+- Native desktop/mobile readers (Reeder) load `http://` images fine (no HTTPS page context), so they **mask** the bug.
+- A `curl -I http://…/image.jpg` only checks that the image is *fetchable* (it is). It misses the real failure: a browser / web reader **refusing to render an HTTP image inside an HTTPS page**.
+
+The reliable check is to render the feed image in an HTTPS page context (a browser web reader, or the site's own Feed Preview served over HTTPS) and watch for a mixed-content block — not to fetch the bytes.
+
+### 2. Let the source's archive shape set the feed window
+
+A fixed image path overwritten daily, with no archive, means exactly **one** retrievable strip exists at any moment: today's. A multi-day window is physically impossible — every entry would resolve to the same (latest) bytes. So:
+
+- Set `FEED_WINDOW = 1`. One-day-only is the **ceiling**, not a tuning choice.
+- Give each day a distinct, stable identity via **fetch-date dating** (`guid = <src>-<date>`, `pub_date` = noon Eastern on capture day). Distinct dates → distinct pub_dates → no dedup collisions, and subscribers still get one new item per day. (This reuses the Far Side "daily dose" model — selection happens upstream, we just record the day.)
+- Add a **date cache-buster** to the image URL so a reader that cached the fixed path yesterday refetches today's bytes: `f"{image_url}?d={target_date}"`.
+
+**Contrast with Far Side**, which *does* have distinct per-strip asset URLs — so a multi-day window works there and needs no cache-buster. Read the source's asset model before copying another source's window.
+
+### 3. If you must run a proxy, harden it against SSRF
+
+A public, unauthenticated Netlify function that fetches a caller-supplied URL is an SSRF target. Validate strictly (see `functions/proxy-farside-image.js`, `functions/proxy-mrboffo-image.js` was removed once HTTPS sourcing replaced it):
+
+- **Exact parsed hostname, never substring.** Parse with `new URL()` and match `parsed.hostname` against an allowlist. `imageUrl.includes('site.com')` accepts `site.com.evil.com`.
+- **Scheme check.** Reject anything that isn't `http:`/`https:` (blocks `file:`, `gopher:`, …).
+- **`redirect: 'manual'`** on the fetch, so an allowed host can't 30x-bounce you to an internal target.
+- **`image/*` responses only**, so the proxy can never become a general-purpose content relay.
+
+### 4. Register branding so the feed title reads right
+
+A new source falls through `feed_generator.py`'s `source_display` map to the `"GoComics"` default, producing e.g. `Mr. Boffo - GoComics`. Add the source's *publisher* label to that map (`'mrboffo': 'Neatly Chiseled Features'`) — the slot is the publisher, not the comic name (avoid `Mr. Boffo - Mr. Boffo`). The one-off custom scrapers (`farside-daily`, `farside-new`) had the same latent gap.
+
+## Why This Matters
+
+- **You avoid operating a service you don't need.** Each Netlify function is an always-on attack surface, an egress cost, and a cold-start tax. Picking the publisher's HTTPS host deleted all of that.
+- **You catch a bug tests and curl can't see.** Mixed-content blocking is invisible to offline unit tests, to native readers, and to a hotlink `curl`. Knowing it manifests *only in an HTTPS page context* is the difference between shipping silently-broken images to web-reader subscribers and catching it before push — and `main` ships live.
+- **You shape the feed from reality, not habit.** Copying a multi-day window onto a single-overwritten-image source emits several entries all resolving to the same image — duplicate-looking strips and confused dedup.
+- **A naive proxy is a real SSRF hole.** A substring host check on a public endpoint lets an attacker make your function fetch arbitrary internal/third-party URLs. The hardening is cheap; the hole is not.
+
+## When to Apply
+
+- Adding any comic hosted on the **artist's/publisher's own site** rather than a syndication CDN.
+- The source serves images over **HTTP**, or you're about to write a proxy "to be safe" — look for an HTTPS sibling host first.
+- The source has **no archive / no per-day permalink / a fixed image path overwritten in place** — before choosing a feed window.
+- **Writing or reviewing any Netlify image proxy** or other server-side fetch of a caller-supplied URL.
+- Diagnosing a feed whose images **render in a desktop reader but break in a web reader** — suspect mixed content; verify in an HTTPS page context, not with curl.
+
+## Examples
+
+**Mixed content: pick the HTTPS host, skip the proxy.**
+
+```python
+# BEFORE — reflexively HTTP source + a proxy to "fix" HTTPS:
+#   image_url = "http://www.mrboffo.com/images/daily/...jpg"
+#   feed_url  = f".../proxy-mrboffo-image?url={quote(image_url)}"
+#   → a whole serverless function to own, plus its SSRF surface
+
+# AFTER — comiccaster/mrboffo_scraper.py: a sibling HTTPS host already exists
+BASE_URL = "https://www.mrboffocomics.com"   # serves the same strip over HTTPS
+# No proxy. No function. Mixed content can't occur.
+```
+
+**Single overwritten image: window=1 + cache-buster + fetch-date dating.**
+
+```python
+# BEFORE — copying a multi-day source's pattern onto a fixed-path source:
+#   FEED_WINDOW = 7
+#   → 7 entries that ALL resolve to today's overwritten image
+
+# AFTER — scripts/generate_mrboffo_feeds.py
+FEED_WINDOW = 1                                    # archive can serve only "today"
+cache_busted_url = f"{image_url}?d={target_date}"  # defeat reader cache of the fixed path
+entries.append({
+    'image_url': cache_busted_url,
+    'pub_date': pub_datetime,                      # noon Eastern, distinct per day
+    'id': f"mrboffo-{target_date}",                # one new guid per day
+})
+```
+
+**Proxy SSRF hardening: exact hostname, not substring.**
+
+```javascript
+// BEFORE — substring check is an SSRF bypass:
+//   if (imageUrl.includes('thefarside.com')) { /* fetch it */ }
+//   → accepts http://thefarside.com.evil.com/  and  http://evil/?x=thefarside.com
+
+// AFTER — functions/proxy-farside-image.js
+const parsed = new URL(imageUrl);                       // parse, don't string-match
+if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return forbidden();
+const host = parsed.hostname.toLowerCase().replace(/\.$/, '');
+if (!allowedHosts.includes(host)) return forbidden();   // exact host allowlist
+const response = await fetch(parsed.toString(), { redirect: 'manual', headers });
+const ct = response.headers.get('content-type') || '';
+if (!ct.toLowerCase().startsWith('image/')) return unsupportedMediaType();
+```
+
+## Related
+
+- GitHub issue #153 — the Mr. Boffo request that originated this work (closed).
+- `comiccaster/mrboffo_scraper.py`, `scripts/generate_mrboffo_feeds.py` — the reference implementation of §1–§2.
+- `functions/proxy-farside-image.js` — the proxy pattern (Far Side genuinely needs one: its images require a `Referer`), with the §3 hardening applied.
+- `comiccaster/feed_generator.py` — `source_display` branding map (§4) and single- vs multi-image description rendering.
+- Disambiguation: `docs/solutions/logic-errors/gocomics-spanish-english-feed-contamination.md` discusses feed-*merge* overwrite semantics — a different "overwrite" from this doc's intentional single-image overwrite.


### PR DESCRIPTION
Documentation pass closing out the Mr. Boffo work (#153–#158).

## Roster updates
Added Mr. Boffo as the **seventh source** wherever the roster is listed:
- `AGENTS.md` (overview, scrape/generate command lists, "seven sources")
- `CLAUDE.md` (unit-test mock list)
- `docs/LOCAL_AUTOMATION_README.md` (pipeline diagram)
- `docs/STATUS.md` (overview, architecture line, feed roster, header date)

## Compound learnings (new)
`docs/solutions/best-practices/mixed-content-and-single-image-comic-sources.md` — the reusable playbook from adding a self-hosted comic source:
1. **Prefer a publisher HTTPS URL over running our own proxy** (we sourced Mr. Boffo from `mrboffocomics.com` HTTPS and deleted the proxy).
2. **Mixed-content diagnosis** — it only fails in an HTTPS *browser/web-reader* context; native readers (Reeder) and `curl` hotlink tests mask it.
3. **Single-overwritten-image feed shape** — window=1 + date cache-buster + fetch-date dating; one-day-only is the ceiling (contrast: Far Side has distinct per-strip URLs).
4. **Image-proxy SSRF hardening** — exact parsed hostname (not substring), scheme check, `redirect: 'manual'`, image-only responses.

## Shared vocabulary (new)
`CONCEPTS.md` seeded with the comic-source domain: Source, self-hosted-feed vs external-RSS source, the scrape/generate pipeline + invariant guard, Daily Dose, feed window. Surfaced in `CLAUDE.md` (alongside a note that `docs/solutions/` is a searchable, frontmatter-indexed store) so future sessions find both.

Docs-only; no code or feed changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)