### PR TITLE
fix: rolling backfill for late/next-day GoComics political cartoonists (#164)

### DIFF
--- a/docs/plans/2026-07-10-001-fix-gocomics-late-publisher-backfill-plan.md
+++ b/docs/plans/2026-07-10-001-fix-gocomics-late-publisher-backfill-plan.md
@@ -1,0 +1,459 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+title: "fix: Rolling backfill for late/next-day GoComics political cartoonists"
+date: 2026-07-10
+type: fix
+depth: standard
+github_issues: [164]
+related_docs:
+  - docs/solutions/logic-errors/gocomics-favorites-page-timing.md
+---
+
+# fix: Rolling backfill for late/next-day GoComics political cartoonists (#164)
+
+## Summary
+
+GoComics political cartoonists who publish *after* our Pass 2 scrape window (13:00 PT
+/ 16:00 ET) — or on a next-day lag — are silently and permanently dropped from their
+feeds. Jack Ohman (#164) is the reported case; on 2026-07-08 he was one of **11 of 25**
+political comics that published but were missed by both daily passes. Because a comic
+missed on its publish date is never written to any `data/comics_<date>.json`, the feed
+never recovers it.
+
+This plan adds a **rolling backfill**: each daily run re-scrapes the political favorites
+page for the last ~3 days (using the page's `?date=` parameter, which returns the correct
+*settled* state for a past date) and merges any newly-appeared slugs into that day's
+existing `data/comics_<date>.json`, then regenerates GoComics feeds. It reuses the proven
+extraction and merge code paths and is robust to any publish time, including next-day
+posters.
+
+This extends the two-pass fix from #138 (`docs/solutions/logic-errors/gocomics-favorites-page-timing.md`),
+which caught the mid-morning syndication wave but not this later tail.
+
+---
+
+## Problem Frame
+
+**Confirmed root cause (not an extraction bug — a timing/coverage gap):**
+
+- The GoComics favorites page is *reactive*: a cartoonist appears in the "updated today"
+  (`ComicViewer`) set only once their strip has actually posted; otherwise they sit in
+  the `FeaturesNotIssued` section. The `?date=` query selects which day's strips to show,
+  but published-vs-not is evaluated as of the HTTP request time.
+- Our production scrape runs Pass 1 (~03:20 PT) and Pass 2 (~13:00 PT). At those times
+  only ~7–11 of the ~61 comics the favorites page lists on a given day show as "updated"
+  (the roster is 71 configured political comics in `public/political_comics_list.json`; the
+  page shows the subset issuing/not-issuing that day). Late/evening-Eastern and next-day
+  posters are still in `FeaturesNotIssued` and are never captured.
+- A slug missed on its publish date is never written to *any* dated JSON, and
+  `scripts/generate_gocomics_feeds.py` only builds feeds from what the JSONs contain — so
+  the miss is permanent.
+
+**Evidence (via `scripts/diagnose_political_favorites.py`, run 2026-07-10):**
+
+- Re-fetching the political page with `?date=2026-07-08` now shows `jackohman` in the
+  `ComicViewer` (updated) set, and replaying the production extractor against that saved
+  HTML pulls him out cleanly (valid strip image present). So the extractor is fine — the
+  page simply didn't show him as updated at scrape time.
+- Comparing that settled Jul-8 "updated" set against `data/comics_2026-07-08.json`: 11
+  published political comics were missed — `bill-bramhall`, `chrisbritt`, `garymarkstein`,
+  `garyvarvel`, `henrypayne`, `jackohman`, `jeffstahler`, `joe-heller`, `kal`, `mattdavies`,
+  `pedroxmolina`. Jack Ohman is captured only ~once every 1–2 weeks (7 days since April),
+  which is the same systemic gap, not an Ohman-specific issue.
+
+**Who is affected:** RSS subscribers to any late/next-day-publishing political cartoonist
+on GoComics; the reporter and #138's reporter are concrete examples.
+
+---
+
+## Scope Boundaries
+
+**In scope:**
+- Date-aware fetching of the political favorites page (append `?date=` for a past date).
+- A rolling backfill over the last N days (default 3, configurable) that merges
+  newly-appeared slugs into each `data/comics_<date>.json`.
+- Wiring the backfill into the daily pipeline by extending Pass 2
+  (`scripts/local_pass2_update.sh`), including fixing its push-conflict recovery to
+  preserve *all* touched date files, not just today's.
+- Regenerating GoComics feeds so recovered strips appear.
+- Updating the #138 solution doc to record the late/next-day tail and this fix.
+
+**Out of scope / non-goals:**
+- The 5 daily-comics custom pages. The misses are concentrated in the political page; the
+  daily pages already run ~60–68/99 updated and publish reliably overnight. Cheap to widen
+  later if a daily-comic gap is ever reported (the backfill loop is page-agnostic; only the
+  page-selection filter changes).
+- Comics Kingdom, TinyView, Far Side, New Yorker, Creators, Mr. Boffo — none uses a single
+  reactive favorites page.
+- Backfilling *history* beyond the rolling window. This fixes forward; recovering April–July
+  Ohman gaps is a one-off manual `diagnose`/backfill task, not this change.
+
+### Deferred to Follow-Up Work
+- Widening the backfill to all 6 custom pages if a daily-comic late-publish gap is reported.
+- Auto-tuning the window length from observed backfill hit-rates (the #138 doc already
+  floats self-tuning; not needed yet — YAGNI).
+
+---
+
+## Alternatives Considered
+
+- **Option A — add a later same-day Pass 3 (~18:00–20:00 PT) instead of a backfill.**
+  Simpler, but it only shifts the cutoff later: anyone posting after ~18:00 PT or on a
+  next-day lag still slips through, and the miss is still permanent. The backfill subsumes
+  A's benefit (it re-checks yesterday and the day before, well past any evening wave) *and*
+  catches next-day posters. Rejected as insufficient on its own; not built.
+- **Option B via `scripts/backfill_gocomics_feeds.py` (per-comic HTTP page fetches).**
+  That script fetches each comic's individual page per date. It is explicitly "manual
+  recovery, NOT part of the daily pipeline," is rate-limited (`MAX_WORKERS=2`), and for the
+  71 configured political comics × 3 days would issue ~200 requests (vs one page fetch × 3
+  days for the favorites-page route). The favorites-page route reuses the
+  authenticated extraction path already trusted in production, needs one login and a handful
+  of page fetches, and exercises the same `merge_with_existing` semantics. Rejected in favor
+  of the favorites-page backfill.
+
+---
+
+## Key Technical Decisions
+
+- **KTD1 — Reactive page + `?date=` is the recovery mechanism.** The favorites page returns
+  the updated/not-issued classification for a past date as of request time. Re-fetching
+  yesterday and the day before recovers anything that published late or next-day, which is
+  exactly the failure mode. The diagnostic proved this for `?date=2026-07-08` (n=1). Two
+  properties make the mechanism robust despite that single data point: (a) each past date is
+  *re-fetched on every subsequent day it remains in the window* — a date enters as `today-1`
+  and is scraped again as `today-2` and `today-3`, so a strip that is still settling on the
+  first backfill pass is caught on a later one; (b) the window is the only knob, and widening
+  it (R5) extends the recovery horizon. Late settling within the window is therefore self-
+  healing; only lateness *exceeding* the window is missed.
+- **KTD2 — Reuse `extract_comics_from_page` and `merge_with_existing` unchanged.** Extraction
+  is already correct (proven by replay). `merge_with_existing` implements "new wins on slug
+  overlap, preserve existing disjoint slugs": backfill is *additive* for slugs not yet in the
+  target file, and *replacive* for slugs already present (the re-scraped entry overwrites the
+  prior one). Overwrite is safe here — the settled `?date=` page returns the same publication-
+  date strip, so a replaced entry is the same-or-fresher asset for the same date, never a
+  different comic. The new code is URL date-awareness + a date loop + wiring, not new
+  extraction/merge logic.
+- **KTD3 — Merge into each date's own file, keyed on the scraped date.** Backfilling
+  `?date=2026-07-08` writes/merges into `data/comics_2026-07-08.json`. `generate_gocomics_feeds.py`
+  loads the last 90 daily files, so a recovered Jul-8 entry surfaces in the feed dated Jul 8.
+  The generator sets each item's guid to the comic URL (`gocomics.com/<slug>/2026/07/08`),
+  which is date-unique, so a recovered strip is a new guid, not a duplicate. For Ohman
+  specifically it is also *newer* than the previously-newest Jul 2, so every reader shows it.
+  **Known limitation:** a recovered strip whose date falls *before* a subscriber's newest-seen
+  item is back-dated; some RSS readers suppress items older than the newest already delivered,
+  so those subscribers may not surface a deep-window recovery. Acceptable — the common case
+  (recovering the last day or two) is at or near the feed head.
+- **KTD4 — Political page only, selected by category.** Backfill iterates
+  `config['custom_pages']` filtered to `category == 'political'` (matches the diagnostic's
+  own page-selection convention). Page-agnostic loop; widening later is a one-line filter
+  change.
+- **KTD5 — Fold into Pass 2, not a new cron entry.** Pass 2 already owns GoComics re-scrape →
+  merge → regenerate → commit → push-with-recovery. The backfill is the same shape on more
+  date files. This avoids a second scheduled job and a second login flow, at the cost of the
+  wiring fixes in U3. **Durability precondition:** Pass 2 opens with `git reset --hard
+  origin/main` (`scripts/local_pass2_update.sh:62`), so every backfilled past-date file must be
+  *committed and pushed within the same run* — writing it to disk is not enough; the next day's
+  reset discards anything un-pushed. This makes U3's staging fix (both the happy-path commit and
+  the recovery block) load-bearing, not optional.
+
+---
+
+## Requirements
+
+- **R1** — The daily pipeline captures a political cartoonist's strip even when it publishes
+  after Pass 2 or on a next-day lag, within the rolling window. (Covers #164.)
+- **R2** — Backfill never drops a slug already present in a target date's JSON. It adds
+  missed slugs and, for a slug already present, replaces its entry with the re-scraped
+  same-date strip (same publication date, same-or-fresher asset) — never a different comic.
+- **R3** — Backfill reuses the existing extraction and merge code paths; no divergent parsing.
+- **R4** — Recovered strips appear in the correct per-date feed entry after regeneration.
+- **R5** — The window length is configurable (default 3 days) without code edits to core logic.
+- **R6** — Every Pass 2 commit path — the normal happy path *and* the push-conflict recovery —
+  stages every date file the run touched, not just today's.
+- **R7** — Unit tests are offline; no live GoComics access in the default `pytest -v` run.
+
+---
+
+## High-Level Technical Design
+
+Daily timeline and where the backfill closes the gap:
+
+```mermaid
+sequenceDiagram
+    participant Cron as launchd (daily)
+    participant P1 as Pass 1 ~03:20 PT
+    participant P2 as Pass 2 ~13:00 PT (extended)
+    participant GC as GoComics political page
+    participant Data as data/comics_&lt;date&gt;.json
+    participant Feed as public/feeds/*.xml
+
+    P1->>GC: fetch today (no ?date=)
+    GC-->>P1: ~7-11 of 61 updated (early wave)
+    P1->>Data: write comics_TODAY.json
+
+    P2->>GC: fetch today (--merge)
+    GC-->>P2: mid-morning wave
+    P2->>Data: merge into comics_TODAY.json
+
+    Note over P2,GC: NEW backfill loop (last N days)
+    loop date in [TODAY-1 .. TODAY-N]
+        P2->>GC: fetch ?date=&lt;date&gt; (settled state)
+        GC-->>P2: late/next-day posters now "updated"
+        P2->>Data: merge_with_existing -> comics_&lt;date&gt;.json
+    end
+
+    P2->>Feed: regenerate GoComics feeds (loads 90 days)
+    Note over Feed: recovered strips appear, dated correctly
+```
+
+Decision flow inside the extended scraper:
+
+```mermaid
+flowchart TD
+    A[scrape run] --> B{backfill mode?}
+    B -- no --> C[fetch each custom page, today's view]
+    B -- yes --> D[filter custom_pages to category=political]
+    D --> E[for each date in last N days]
+    E --> F["append ?date=&lt;date&gt; to page URL"]
+    F --> G[extract_comics_from_page]
+    G --> H["merge_with_existing into comics_&lt;date&gt;.json"]
+    H --> E
+```
+
+*Directional guidance for review — not implementation specification.*
+
+---
+
+## Implementation Units
+
+### U1. Date-aware favorites-page URL construction
+
+**Goal:** Let the scraper fetch a specific past date's view of a custom page by appending
+`?date=<YYYY-MM-DD>` (respecting an existing `?` in the URL), mirroring how
+`scripts/diagnose_political_favorites.py` already builds `target_url`.
+
+**Requirements:** R3.
+**Dependencies:** none.
+**Files:**
+- `scripts/authenticated_scraper_secure.py` (add a small pure helper, e.g. `page_url_for_date(base_url, date_str)`)
+- `tests/test_authenticated_scraper.py` (new test class)
+
+**Approach:** Extract the diagnostic's one-liner (`f"{base_url}{'&' if '?' in base_url else '?'}date={date}"`)
+into a named helper on the production scraper so both the daily path and the new backfill
+path share it. `extract_comics_from_page` already accepts a fully-formed URL, so no change to
+extraction — only the URL passed in.
+
+**Patterns to follow:** `scripts/diagnose_political_favorites.py` `target_url` construction;
+existing pure-helper tests in `tests/test_authenticated_scraper.py` (`TestExtractComicSlugFromLink`).
+
+**Test scenarios:**
+- Base URL without a query string gets `?date=2026-07-08` appended.
+- Base URL that already contains a `?` (query param) gets `&date=...` appended.
+- Returned string is otherwise byte-identical to the base URL (no trailing slash mangling).
+
+**Verification:** New helper unit tests pass; no behavior change to existing daily scrape.
+
+---
+
+### U2. Rolling backfill loop over recent dates
+
+**Goal:** Add a backfill mode that, in one authenticated session, iterates the last N days,
+fetches the political favorites page(s) with `?date=`, extracts, and merges results into each
+day's `data/comics_<date>.json` via `merge_with_existing`.
+
+**Requirements:** R1, R2, R3, R4, R5.
+**Dependencies:** U1.
+**Files:**
+- `scripts/authenticated_scraper_secure.py` (add `--backfill-days N` CLI flag and a backfill
+  routine; select political pages via `category == 'political'`; reuse `extract_comics_from_page`
+  and `merge_with_existing`; add `category` metadata to each comic as the daily path does)
+- `tests/test_authenticated_scraper.py` (new test class for the backfill routine)
+
+**Approach:** A new routine computes the target dates (`today-1 .. today-N`; today itself is
+already covered by the same-day Pass 2 merge, so the backfill targets *past* dates). For each
+date it builds the URL (U1), scrapes with the existing extractor, stamps `category='political'`,
+and merges into `output_dir / f'comics_{date}.json'` using `merge_with_existing`. Default N=3,
+overridable via `--backfill-days` (and/or an env var, e.g. `GOCOMICS_BACKFILL_DAYS`, for the
+pipeline — implementer's choice; keep the default in one place per R5). Structure the routine so
+the per-date scrape/merge is unit-testable with the extraction function mocked (mirror how
+`TestExtractComicsFromPage` uses `_mock_driver`).
+
+**Composition with the existing `main()`:** the backfill is an *additional* loop that runs
+after the existing same-day scrape/write, reusing the same authenticated driver session — not a
+replacement for the same-day path. `main()` currently scrapes today's custom pages, dedupes
+cross-page, and writes one `comics_TODAY.json`; the backfill loop runs when `--backfill-days > 0`
+and writes each past date to *its own* `comics_<date>.json`. The routine should return (or log)
+the exact list of date files it touched so U3's staging step can enumerate them.
+
+**Execution note:** Implement test-first — write the failing backfill-loop test (mocked
+extraction, `tmp_path` for date files) before the routine, then make it green. This is the
+core behavioral unit.
+
+**Patterns to follow:** `main()` in `scripts/authenticated_scraper_secure.py` for the
+login → per-page extract → `category` stamping → `merge_with_existing` → write sequence;
+`TestMergeWithExisting` and `TestExtractComicsFromPage` for mocking style; date iteration in
+`scripts/backfill_gocomics_feeds.py` (`target_dates` via `timedelta`).
+
+**Test scenarios:**
+- **Happy path:** given a mocked extractor returning `jackohman` for `?date=2026-07-08` and an
+  existing `comics_2026-07-08.json` lacking him, the merged file gains `jackohman` and keeps all
+  prior slugs. (Covers R1, R2.)
+- **Additive/no-op:** when the backfill returns only slugs already present for that date, the file
+  content is unchanged (same slugs, no dropped entries).
+- **Multiple dates:** N=3 iterates exactly the 3 prior dates and writes/merges each into its own
+  `comics_<date>.json` (no cross-date contamination).
+- **Missing target file:** backfilling a date with no existing JSON creates it from the scrape
+  (relies on `merge_with_existing` returning new data when the file is absent).
+- **Category stamping:** every backfilled comic carries `category='political'`.
+- **Edge — window boundary:** `--backfill-days 1` targets only `today-1`; `0` targets nothing
+  (documented behavior, no crash).
+- **Isolation:** the routine performs no live network in tests (extraction mocked); asserts the
+  default run stays offline. (Covers R7.)
+
+**Verification:** `pytest -v tests/test_authenticated_scraper.py` green; running
+`authenticated_scraper_secure.py --backfill-days 3` locally against live GoComics merges recovered
+slugs into the prior days' JSONs (manual, out-of-test check).
+
+---
+
+### U3. Wire backfill into Pass 2 and stage all touched date files
+
+**Goal:** Run the backfill as part of the daily Pass 2, regenerate GoComics feeds, and — the
+load-bearing part — make **every** commit path in Pass 2 stage all the date files the run
+touched, not just today's. Missing this means recovered strips are regenerated into feeds but
+their JSON is never committed, and the next run's `git reset --hard origin/main` silently wipes
+them (see KTD5 durability precondition).
+
+**Requirements:** R1, R4, R6.
+**Dependencies:** U2.
+**Files:**
+- `scripts/local_pass2_update.sh`
+
+**Approach:** After the existing same-day `--merge` scrape, run the backfill in the *same*
+invocation (`--backfill-days N`, one login). Regeneration is already network-free and loads 90
+days, so no generator change is needed. Then fix staging in the three places that currently
+hardcode today's file. The backfill window is a known, computable set of dates, so build an
+explicit enumerated path list (from the same date loop U2 uses) — **never** a
+`data/comics_*.json` glob, which would force-add stale/leftover dated JSONs past `.gitignore`
+(which ignores `comics_*.json`) and reintroduce the blind-add risk CLAUDE.md forbids. Concretely:
+
+1. **Happy-path stage (`scripts/local_pass2_update.sh:110`):** currently
+   `git add -f "data/comics_$DATE_STR.json" public/feeds/*.xml` — stages only today. Extend to
+   force-add each enumerated `data/comics_<date>.json` in the window plus `public/feeds/*.xml`.
+   This is the majority path and the one the original plan missed.
+2. **Recovery save (`:132-134`):** currently copies only `$PASS1_FILE` into the staging dir.
+   Extend to copy every touched date file. The **restore loop (`:141-143`) already globs
+   `$STAGING/*.json`** and needs no change — mirror the glob-save/glob-restore pattern already in
+   `scripts/local_master_update.sh:302`.
+3. **Recovery stage (`:150`):** same fix as (1), applied to the post-recovery `git add`.
+
+**Execution note:** Shell wiring; prefer a local dry-run / smoke check (run Pass 2 by hand,
+confirm every touched date file is staged and committed on the happy path, and simulate a push
+conflict to confirm the recovery path preserves them) over unit coverage. The happy-path staging
+fix is the one to verify hardest — it is the common case.
+
+**Patterns to follow:** the glob-save-then-glob-restore recovery choreography in
+`scripts/local_master_update.sh` (around `:302`/`:313`); existing Pass 2 phase structure.
+
+**Test scenarios:** `Test expectation: none — shell orchestration; covered by U2 unit tests plus a
+manual Pass 2 smoke run.` Verify by inspection: (a) backfill runs after the same-day merge in one
+login; (b) regeneration runs once after all merges; (c) **all three** staging points enumerate
+the full touched-date list; (d) no `comics_*.json` glob is used for force-add.
+
+**Verification:** A manual Pass 2 run backfills the last 3 days, regenerates feeds, and commits;
+`git log -1 --stat` shows every touched `data/comics_<date>.json` in the commit (not just today's);
+`git status` is clean afterward; a simulated push conflict confirms past-date files survive the
+`reset --hard` via the recovery path.
+
+---
+
+### U4. Recover Jack Ohman now and document the fix
+
+**Goal:** Close #164 concretely (get Ohman's missing strips into his live feed) and capture the
+learning so the next session inherits it.
+
+**Requirements:** R1, R4.
+**Dependencies:** U2 (backfill exists), U3 (or a manual invocation).
+**Files:**
+- `docs/solutions/logic-errors/gocomics-favorites-page-timing.md` (append a section: the late/
+  next-day tail beyond Pass 2, the 2026-07-08 evidence, and the rolling-backfill fix; keep #138
+  context intact and add #164)
+- `public/feeds/jackohman.xml` and affected `data/comics_<date>.json` (regenerated/merged output —
+  committed as feed-data, separately from the code change per CLAUDE.md)
+
+**Approach:** Run the backfill (or a one-off wider `diagnose`/backfill) for the dates the reporter
+flagged as missing since Jul 2, regenerate, and confirm the new entries appear in `jackohman.xml`.
+Update the solution doc. Commit code (U1–U3 + doc) and feed-data separately.
+
+**Execution note:** Live-data recovery step — run against GoComics manually; not part of the
+offline test suite.
+
+**Patterns to follow:** existing solution-doc frontmatter and section style in
+`docs/solutions/logic-errors/gocomics-favorites-page-timing.md`.
+
+**Test scenarios:** `Test expectation: none — documentation and live-data recovery.` Verify by
+confirming Ohman's post-Jul-2 strips are present in `public/feeds/jackohman.xml` with correct
+`pubDate`s.
+
+**Verification:** `jackohman.xml` contains the previously-missing dated entries; solution doc
+updated with #164 and the late/next-day tail.
+
+---
+
+## Risks & Dependencies
+
+- **Live-page shape drift.** If GoComics changes the favorites-page DOM, both the daily scrape and
+  the backfill break together (shared extractor) — no new surface, and the `?date=` behavior is
+  already proven. Mitigation: `scripts/diagnose_political_favorites.py` remains the go-to probe.
+- **Auth/session cost.** The backfill adds a few page fetches per run inside the existing login;
+  negligible. Do not store cookies — keep the fresh-login-per-run model. Never commit session
+  artifacts (SECURITY.md).
+- **Recovery correctness (R6).** The multi-date recovery change is the one place a bug could lose
+  data on a push conflict. Treat U3's recovery edit carefully; verify by inspection/dry-run.
+- **Window too short.** If a cartoonist lags more than N days, they're still missed. N=3 is a
+  *provisional* default: the confirmed evidence shows a 1-day (next-day) lag for Ohman, and 3 days
+  adds margin, but the lateness distribution across the affected ~11 comics isn't yet measured.
+  Treat 3 as a starting value to tune from observed backfill hit-rates (see Deferred); widen via
+  config (R5) if a longer lag is reported. Mitigating factor: each date is re-fetched on every
+  subsequent in-window day (KTD1), so within-window late settling is self-healing.
+- **Dependency:** `authenticated_scraper_secure.py` login flow and `merge_with_existing`
+  (unchanged, reused).
+
+---
+
+## Definition of Done
+
+- U1–U3 implemented; `pytest -v` green (coverage on, offline).
+- Backfill runs in Pass 2 over the last 3 days, merges additively, and regenerates feeds.
+- Both Pass 2 commit paths (happy path and push-conflict recovery) stage all touched date files.
+- Window length is config-driven (default 3).
+- Jack Ohman's missing post-Jul-2 strips are recovered into `public/feeds/jackohman.xml`.
+- `docs/solutions/logic-errors/gocomics-favorites-page-timing.md` updated for #164.
+- Code and feed-data committed separately, explicit paths only; `main` pushed only after a green run.
+
+---
+
+## Verification Contract
+
+- `pytest -v` passes with no new network calls in the default run (R7).
+- New unit tests cover: date-aware URL construction (U1), backfill happy-path/additive/multi-date/
+  missing-file/boundary (U2).
+- Manual: a Pass 2 run backfills 3 days, regenerates, stages only intended paths, and recovers
+  Ohman's strips (U3, U4).
+
+---
+
+## Sources & Research
+
+- GitHub issue #164 — "Jack Ohman feed not updating."
+- `docs/solutions/logic-errors/gocomics-favorites-page-timing.md` — #138 two-pass fix this extends.
+- `scripts/diagnose_political_favorites.py` — used to confirm root cause on 2026-07-08.
+- Live diagnostic run (2026-07-10): `jackohman` present in settled `?date=2026-07-08` updated set;
+  production extractor replays cleanly against the saved HTML; 11 of 25 political comics missed on
+  Jul 8.
+- Code: `scripts/authenticated_scraper_secure.py` (`extract_comics_from_page`, `merge_with_existing`,
+  `main`), `scripts/local_pass2_update.sh`, `scripts/generate_gocomics_feeds.py` (90-day load),
+  `scripts/backfill_gocomics_feeds.py` (rejected heavier alternative), `tests/test_authenticated_scraper.py`.

--- a/docs/solutions/logic-errors/gocomics-favorites-page-timing.md
+++ b/docs/solutions/logic-errors/gocomics-favorites-page-timing.md
@@ -2,9 +2,9 @@
 title: "GoComics favorites page is reactive: scraping at 03:20 PT misses late-publishing political cartoonists"
 date: 2026-05-16
 category: logic-errors
-tags: [scraping, gocomics, timing, political-cartoons, favorites-page, page-state]
+tags: [scraping, gocomics, timing, political-cartoons, favorites-page, page-state, backfill]
 stack: [python, selenium, beautifulsoup]
-github_issues: [138]
+github_issues: [138, 164]
 ---
 
 ## Problem
@@ -61,8 +61,51 @@ python scripts/diagnose_political_favorites.py --date YYYY-MM-DD --target-slug <
 - **Extraction bug** — replaying the production extractor against the diagnostic HTML extracts all 21 slugs successfully.
 - **Pagination / lazy-load** — only 21 of 63 ComicViewer containers extract cleanly, but the other 42 are responsive-layout duplicates; deduplication is working correctly.
 
+## Update — issue #164: the late/next-day tail beyond Pass 2
+
+GitHub #164 reported Jack Ohman's feed stale since 2026-07-02. Same class of bug as
+#138, but one the two-pass fix above does **not** catch: cartoonists who publish
+*after* the 13:00 PT Pass 2 window, or on a next-day lag.
+
+**Evidence (2026-07-10, via `scripts/diagnose_political_favorites.py`):** re-fetching the
+political page with `?date=2026-07-08` showed `jackohman` in the `ComicViewer` (updated)
+set, and replaying the production extractor against that saved HTML pulled him out cleanly
+(valid strip image) — so it is a timing gap, not an extraction bug. Cross-checking the
+settled Jul-8 "updated" set against `data/comics_2026-07-08.json` found **11 of 25**
+political comics that published Jul 8 were missed by both passes: `bill-bramhall`,
+`chrisbritt`, `garymarkstein`, `garyvarvel`, `henrypayne`, `jackohman`, `jeffstahler`,
+`joe-heller`, `kal`, `mattdavies`, `pedroxmolina`. Jack Ohman had been captured only ~7
+days since April — the same systemic tail, not an Ohman-specific problem. A slug missed on
+its publish date is never written to any dated JSON, so the miss was permanent.
+
+**Fix — rolling backfill (issue #164).** The favorites page is reactive in our favour too:
+re-fetching `?date=<past-date>` returns that day's *settled* updated/not-issued state once
+the strip exists. So each daily run now re-scrapes the political favorites page for the last
+`GOCOMICS_BACKFILL_DAYS` days (default 3) and merges any newly-appeared slugs into that day's
+`data/comics_<date>.json`:
+
+- `scripts/authenticated_scraper_secure.py` gained `page_url_for_date()`, `backfill_target_dates()`,
+  `run_backfill()`, and a `--backfill-days N` flag. After the same-day scrape it re-fetches the
+  political page(s) for each past date (one login) and merges via the existing
+  `merge_with_existing` (additive for new slugs, replacive for overlapping same-date ones).
+- `scripts/local_pass2_update.sh` runs it (`--backfill-days "$BACKFILL_DAYS"`) and — the
+  load-bearing part — stages **every** date file the run touched (today plus the backfill
+  window) on both the happy-path commit and the push-conflict recovery. Previously all three
+  staging points hardcoded today's file, so backfilled past-date JSON would regenerate into
+  feeds but never commit, then be wiped by the next run's `git reset --hard origin/main`. The
+  touched-date set is an explicit enumerated list, never a `data/comics_*.json` glob.
+
+**Why 3 days is robust despite next-day/late posting:** each past date is re-fetched on every
+subsequent in-window day (enters as `today-1`, re-scraped as `today-2`, `today-3`), so
+within-window late settling is self-healing. Only lateness *exceeding* the window is missed;
+`GOCOMICS_BACKFILL_DAYS` widens it without code edits. Recovering a gap *older* than the
+window (e.g. #164's Jul 2–7 backlog) is a one-off wider `--backfill-days` run.
+
 ## Related
 
 - Issue #138 (Nick Anderson missing from GoComics feed)
-- `scripts/authenticated_scraper_secure.py` — the production GoComics scraper
+- Issue #164 (Jack Ohman feed not updating — the late/next-day tail)
+- Plan: `docs/plans/2026-07-10-001-fix-gocomics-late-publisher-backfill-plan.md`
+- `scripts/authenticated_scraper_secure.py` — the production GoComics scraper + rolling backfill
+- `scripts/local_pass2_update.sh` — Pass 2, which runs the backfill and stages all touched dates
 - `docs/solutions/logic-errors/gocomics-spanish-english-feed-contamination.md` — prior GoComics scrape-correctness work

--- a/scripts/authenticated_scraper_secure.py
+++ b/scripts/authenticated_scraper_secure.py
@@ -134,6 +134,18 @@ def login(driver, email, password):
         return False
 
 
+def page_url_for_date(base_url, date_str):
+    """Return the favorites-page URL for a specific date via the ?date= param.
+
+    The GoComics favorites page renders a given day's strips when passed a
+    ?date=YYYY-MM-DD query param. Appends it with the correct separator so a
+    base URL that already carries a query string is respected. Mirrors the
+    construction in scripts/diagnose_political_favorites.py.
+    """
+    separator = '&' if '?' in base_url else '?'
+    return f"{base_url}{separator}date={date_str}"
+
+
 def _extract_comic_slug_from_link(href):
     """Extract a comic slug from a link href, handling both absolute and relative URLs.
 

--- a/scripts/authenticated_scraper_secure.py
+++ b/scripts/authenticated_scraper_secure.py
@@ -9,7 +9,7 @@ import os
 import json
 import re
 import argparse
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from urllib.parse import urlparse
 from selenium import webdriver
@@ -362,6 +362,72 @@ def merge_with_existing(output_file: Path, new_comics: list) -> list:
     return merged
 
 
+def backfill_target_dates(reference_date, days):
+    """Return the `days` dates immediately before `reference_date`, oldest first.
+
+    `reference_date` (today) is excluded — the same-day pass already covers it.
+    e.g. (2026-07-10, 3) -> ['2026-07-07', '2026-07-08', '2026-07-09'].
+    """
+    return [
+        (reference_date - timedelta(days=offset)).strftime('%Y-%m-%d')
+        for offset in range(days, 0, -1)
+    ]
+
+
+def run_backfill(driver, custom_pages, output_dir, days, reference_date=None):
+    """Re-scrape the political favorites page(s) for recent past dates and merge.
+
+    The favorites page is reactive: a cartoonist who published after our daily
+    passes only shows as "updated" on a later fetch of the same ?date=. This
+    re-fetches the last `days` days and merges any newly-appeared slugs into the
+    existing data/comics_<date>.json via merge_with_existing (additive for new
+    slugs, replacive for overlapping ones — same publication date).
+
+    Returns the list of Path files touched (one per backfilled date), which the
+    pipeline uses to stage exactly those files.
+    """
+    if days <= 0:
+        return []
+
+    political_pages = [p for p in custom_pages if p.get('category') == 'political']
+    if not political_pages:
+        print("⚠️  Backfill: no political custom pages configured; skipping")
+        return []
+
+    if reference_date is None:
+        reference_date = datetime.now().date()
+
+    touched = []
+    for date_str in backfill_target_dates(reference_date, days):
+        day_comics = []
+        for page in political_pages:
+            url = page_url_for_date(page['url'], date_str)
+            comics = extract_comics_from_page(driver, url, date_str)
+            for comic in comics:
+                comic['category'] = 'political'
+            day_comics.extend(comics)
+
+        # Deduplicate across political pages (a slug may appear on more than one).
+        seen = set()
+        unique = []
+        for comic in day_comics:
+            slug = comic.get('slug')
+            if not slug or slug in seen:
+                continue
+            seen.add(slug)
+            unique.append(comic)
+
+        output_file = output_dir / f'comics_{date_str}.json'
+        merged = merge_with_existing(output_file, unique)
+        with open(output_file, 'w') as f:
+            json.dump(merged, f, indent=2)
+        touched.append(output_file)
+        print(f"🗓️  Backfill {date_str}: {len(unique)} scraped → "
+              f"{output_file.name} now holds {len(merged)} entries")
+
+    return touched
+
+
 def main():
     parser = argparse.ArgumentParser(
         description='Secure authenticated scraper for GoComics'
@@ -372,6 +438,12 @@ def main():
     parser.add_argument('--merge', action='store_true',
                         help='Merge with existing same-day file instead of overwriting. '
                              'Used by the second daily pass to capture late-publishing comics.')
+    parser.add_argument('--backfill-days', type=int, default=0,
+                        help='After the same-day scrape, re-scrape the political favorites '
+                             'page(s) for the last N days (via ?date=) and merge newly-'
+                             'appeared slugs into each data/comics_<date>.json. Recovers '
+                             'cartoonists who published after the daily passes. Default 0 '
+                             '(off); the daily pass-2 pipeline sets this to 3.')
 
     args = parser.parse_args()
     
@@ -440,7 +512,18 @@ def main():
         print(f"✅ SUCCESS! Extracted {len(all_comics)} comics for {date_str}")
         print(f"💾 Saved to {output_file}")
         print(f"{'='*80}\n")
-        
+
+        # Rolling backfill: recover political cartoonists who published after the
+        # daily passes by re-scraping recent past dates and merging (issue #164).
+        if args.backfill_days > 0:
+            print(f"🔁 Rolling backfill: re-scraping political page(s) for the last "
+                  f"{args.backfill_days} day(s)")
+            reference_date = datetime.strptime(date_str, '%Y-%m-%d').date()
+            touched = run_backfill(driver, config['custom_pages'], output_dir,
+                                   args.backfill_days, reference_date=reference_date)
+            print(f"🔁 Backfill touched {len(touched)} date file(s): "
+                  f"{', '.join(p.name for p in touched) or '(none)'}")
+
         driver.quit()
         return 0
         

--- a/scripts/local_pass2_update.sh
+++ b/scripts/local_pass2_update.sh
@@ -8,12 +8,15 @@
 #
 # Design: Reads pass-1's data/comics_$DATE.json, scrapes the GoComics
 # favorites pages again, and merges any newly-published slugs into the
-# same-day file via authenticated_scraper_secure.py --merge. Regenerates
-# only GoComics feeds, then commits and pushes.
+# same-day file via authenticated_scraper_secure.py --merge. It also runs a
+# rolling backfill (--backfill-days) that re-scrapes the political favorites
+# page for the last few days and merges late/next-day publishers into their
+# own comics_<date>.json (issue #164). Regenerates only GoComics feeds, then
+# commits and pushes.
 #
-# Push recovery mirrors local_master_update.sh's strategy: save the
-# merged comics_$DATE.json, reset to origin/main, restore, regenerate,
-# push once. No git pull --rebase.
+# Push recovery mirrors local_master_update.sh's strategy: save every
+# comics_<date>.json the run touched (today plus the backfill window), reset to
+# origin/main, restore, regenerate, push once. No git pull --rebase.
 
 REPO_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 cd "$REPO_DIR"
@@ -56,6 +59,30 @@ DATE_STR=$(date +%Y-%m-%d)
 echo ""
 echo "📅 Target date: $DATE_STR"
 
+# Rolling-backfill window (issue #164). Configurable without editing core logic
+# per R5: set GOCOMICS_BACKFILL_DAYS in the environment to override the default.
+BACKFILL_DAYS="${GOCOMICS_BACKFILL_DAYS:-3}"
+
+# The exact, enumerated set of date files this run may touch: today plus each
+# day in the backfill window. Built explicitly (never a data/comics_*.json glob)
+# so force-adds past .gitignore can't sweep in stale/leftover dated JSON.
+DATE_FILES=("data/comics_$DATE_STR.json")
+for i in $(seq 1 "$BACKFILL_DAYS"); do
+    d=$(date -v-"${i}"d +%Y-%m-%d)
+    DATE_FILES+=("data/comics_$d.json")
+done
+echo "🗂️  Date files in scope: ${DATE_FILES[*]}"
+
+# Stage only the touched date files that actually exist, plus regenerated feeds.
+# Used on both the happy path and the push-conflict recovery path.
+stage_touched_files() {
+    local f
+    for f in "${DATE_FILES[@]}"; do
+        [ -f "$f" ] && git add -f "$f"
+    done
+    git add -f public/feeds/*.xml
+}
+
 # Reset to origin/main before starting. Any uncommitted work or divergent
 # local commits will be discarded — same policy as the master script.
 git fetch origin
@@ -70,9 +97,9 @@ else
 fi
 
 echo ""
-echo "=== Phase 1: GoComics re-scrape with merge ==="
-if python scripts/authenticated_scraper_secure.py --output-dir ./data --merge; then
-    echo "✅ GoComics pass-2 scrape complete"
+echo "=== Phase 1: GoComics re-scrape with merge + rolling backfill ==="
+if python scripts/authenticated_scraper_secure.py --output-dir ./data --merge --backfill-days "$BACKFILL_DAYS"; then
+    echo "✅ GoComics pass-2 scrape + backfill complete"
 else
     echo "❌ GoComics pass-2 scrape failed"
     FAILURES+=("GoComics pass-2 scrape")
@@ -107,7 +134,7 @@ push_with_watchdog() {
     fi
 }
 
-git add -f "data/comics_$DATE_STR.json" public/feeds/*.xml
+stage_touched_files
 
 if git diff --staged --quiet; then
     echo "ℹ️  No changes to commit (pass 2 found nothing new)"
@@ -124,15 +151,17 @@ pass-1 scrape. See docs/solutions/logic-errors/gocomics-favorites-page-timing.md
     else
         echo "⚠️  First push attempt failed. Engaging reset-regenerate recovery..."
 
-        # Pass 2 only touches data/comics_$DATE.json. Save it and the
-        # GoComics feeds we just regenerated; reset; restore the JSON;
-        # regenerate; push once.
+        # Pass 2 touches today's file plus each backfilled date file. Save all
+        # of them and the GoComics feeds we just regenerated; reset; restore the
+        # JSONs; regenerate; push once.
         STAGING=$(mktemp -d)
         echo "📦 Staging pass-2 scrape data to $STAGING"
-        if [ -f "$PASS1_FILE" ]; then
-            cp -p "$PASS1_FILE" "$STAGING/"
-            echo "  saved $(basename "$PASS1_FILE")"
-        fi
+        for f in "${DATE_FILES[@]}"; do
+            if [ -f "$f" ]; then
+                cp -p "$f" "$STAGING/"
+                echo "  saved $(basename "$f")"
+            fi
+        done
 
         git fetch origin
         git reset --hard origin/main
@@ -147,7 +176,7 @@ pass-1 scrape. See docs/solutions/logic-errors/gocomics-favorites-page-timing.md
         echo "🔧 Regenerating GoComics feeds from restored scrape data"
         python scripts/generate_gocomics_feeds.py || FAILURES+=("GoComics regen in pass-2 recovery")
 
-        git add -f "data/comics_$DATE_STR.json" public/feeds/*.xml
+        stage_touched_files
         if git diff --staged --quiet; then
             echo "ℹ️  No changes after regeneration; nothing more to push"
             PUSH_OK=true

--- a/tests/test_authenticated_scraper.py
+++ b/tests/test_authenticated_scraper.py
@@ -186,6 +186,19 @@ class TestRunBackfill:
             data = json.loads((tmp_path / f'comics_{d}.json').read_text())
             assert data[0]['slug'] == 'jackohman' and data[0]['date'] == d
 
+    def test_empty_scrape_preserves_existing_file(self, tmp_path):
+        # A day with no political updates (weekend, holiday) must not wipe the
+        # existing file — merge preserves everything and adds nothing.
+        (tmp_path / 'comics_2026-07-08.json').write_text(
+            json.dumps([_political_comic('doonesbury', '2026-07-08')])
+        )
+        with patch(_EXTRACT, return_value=[]):
+            touched = run_backfill(_mock_driver(''), self._pages, tmp_path,
+                                   days=1, reference_date=date(2026, 7, 9))
+        assert touched == [tmp_path / 'comics_2026-07-08.json']
+        data = json.loads((tmp_path / 'comics_2026-07-08.json').read_text())
+        assert [c['slug'] for c in data] == ['doonesbury']
+
     def test_creates_file_when_absent(self, tmp_path):
         with patch(_EXTRACT, return_value=[_political_comic('jackohman', '2026-07-08')]):
             run_backfill(_mock_driver(''), self._pages, tmp_path,

--- a/tests/test_authenticated_scraper.py
+++ b/tests/test_authenticated_scraper.py
@@ -17,7 +17,10 @@ from scripts.authenticated_scraper_secure import (
     _get_badge_name,
     merge_with_existing,
     page_url_for_date,
+    backfill_target_dates,
+    run_backfill,
 )
+from datetime import date
 
 
 def _make_comic_container(slug, badge_name, image_asset_id, include_strip=True,
@@ -108,6 +111,115 @@ class TestPageUrlForDate:
         # Everything up to the appended query is byte-identical to the base.
         assert result.startswith(base)
         assert result[len(base):] == '?date=2026-07-08'
+
+
+def _political_comic(slug, date_str):
+    """Build a scraped-comic dict as extract_comics_from_page would return."""
+    return {
+        'name': slug.replace('-', ' ').title(),
+        'slug': slug,
+        'image_url': f'https://featureassets.gocomics.com/assets/{slug}',
+        'date': date_str,
+        'url': f"https://www.gocomics.com/{slug}/{date_str.replace('-', '/')}",
+    }
+
+
+_EXTRACT = 'scripts.authenticated_scraper_secure.extract_comics_from_page'
+
+
+class TestBackfillTargetDates:
+    def test_returns_last_n_dates_oldest_first_excluding_reference(self):
+        assert backfill_target_dates(date(2026, 7, 10), 3) == [
+            '2026-07-07', '2026-07-08', '2026-07-09',
+        ]
+
+    def test_one_day_window(self):
+        assert backfill_target_dates(date(2026, 7, 10), 1) == ['2026-07-09']
+
+    def test_zero_days_is_empty(self):
+        assert backfill_target_dates(date(2026, 7, 10), 0) == []
+
+
+class TestRunBackfill:
+    _pages = [
+        {'url': 'https://www.gocomics.com/profile/User1/comics/221821', 'category': 'political'},
+        {'url': 'https://www.gocomics.com/profile/User1/comics/221824', 'category': 'daily'},
+    ]
+
+    def test_adds_missed_slug_and_preserves_existing(self, tmp_path):
+        (tmp_path / 'comics_2026-07-08.json').write_text(
+            json.dumps([_political_comic('doonesbury', '2026-07-08')])
+        )
+
+        def fake_extract(driver, url, date_str):
+            return [_political_comic('jackohman', date_str)] if date_str == '2026-07-08' else []
+
+        with patch(_EXTRACT, side_effect=fake_extract):
+            touched = run_backfill(_mock_driver(''), self._pages, tmp_path,
+                                   days=1, reference_date=date(2026, 7, 9))
+
+        assert touched == [tmp_path / 'comics_2026-07-08.json']
+        data = json.loads((tmp_path / 'comics_2026-07-08.json').read_text())
+        assert {c['slug'] for c in data} == {'doonesbury', 'jackohman'}
+        # backfilled entry is stamped political
+        ohman = next(c for c in data if c['slug'] == 'jackohman')
+        assert ohman['category'] == 'political'
+
+    def test_noop_when_slug_already_present(self, tmp_path):
+        (tmp_path / 'comics_2026-07-08.json').write_text(
+            json.dumps([_political_comic('jackohman', '2026-07-08')])
+        )
+        with patch(_EXTRACT, return_value=[_political_comic('jackohman', '2026-07-08')]):
+            run_backfill(_mock_driver(''), self._pages, tmp_path,
+                         days=1, reference_date=date(2026, 7, 9))
+        data = json.loads((tmp_path / 'comics_2026-07-08.json').read_text())
+        assert [c['slug'] for c in data] == ['jackohman']
+
+    def test_multiple_dates_write_own_files(self, tmp_path):
+        with patch(_EXTRACT, side_effect=lambda d, u, ds: [_political_comic('jackohman', ds)]):
+            touched = run_backfill(_mock_driver(''), self._pages, tmp_path,
+                                   days=3, reference_date=date(2026, 7, 10))
+        assert [p.name for p in touched] == [
+            'comics_2026-07-07.json', 'comics_2026-07-08.json', 'comics_2026-07-09.json',
+        ]
+        for d in ('2026-07-07', '2026-07-08', '2026-07-09'):
+            data = json.loads((tmp_path / f'comics_{d}.json').read_text())
+            assert data[0]['slug'] == 'jackohman' and data[0]['date'] == d
+
+    def test_creates_file_when_absent(self, tmp_path):
+        with patch(_EXTRACT, return_value=[_political_comic('jackohman', '2026-07-08')]):
+            run_backfill(_mock_driver(''), self._pages, tmp_path,
+                         days=1, reference_date=date(2026, 7, 9))
+        assert (tmp_path / 'comics_2026-07-08.json').exists()
+
+    def test_only_political_pages_fetched_with_date_param(self, tmp_path):
+        calls = []
+
+        def fake_extract(driver, url, date_str):
+            calls.append(url)
+            return []
+
+        with patch(_EXTRACT, side_effect=fake_extract):
+            run_backfill(_mock_driver(''), self._pages, tmp_path,
+                         days=1, reference_date=date(2026, 7, 9))
+        assert calls, 'expected at least one political page fetch'
+        assert all('221821' in u for u in calls)          # political page only
+        assert all('221824' not in u for u in calls)      # daily page skipped
+        assert all('date=2026-07-08' in u for u in calls)  # date param applied
+
+    def test_zero_days_performs_no_scrape(self, tmp_path):
+        with patch(_EXTRACT) as mock_extract:
+            touched = run_backfill(_mock_driver(''), self._pages, tmp_path, days=0)
+        assert touched == []
+        mock_extract.assert_not_called()
+
+    def test_no_political_pages_returns_empty(self, tmp_path):
+        daily_only = [{'url': 'https://www.gocomics.com/profile/User1/comics/221824', 'category': 'daily'}]
+        with patch(_EXTRACT) as mock_extract:
+            touched = run_backfill(_mock_driver(''), daily_only, tmp_path,
+                                   days=2, reference_date=date(2026, 7, 10))
+        assert touched == []
+        mock_extract.assert_not_called()
 
 
 class TestGetImageSrc:

--- a/tests/test_authenticated_scraper.py
+++ b/tests/test_authenticated_scraper.py
@@ -16,6 +16,7 @@ from scripts.authenticated_scraper_secure import (
     _get_image_src,
     _get_badge_name,
     merge_with_existing,
+    page_url_for_date,
 )
 
 
@@ -90,6 +91,23 @@ class TestExtractComicSlugFromLink:
 
     def test_rejects_empty_path(self):
         assert _extract_comic_slug_from_link('/') is None
+
+
+class TestPageUrlForDate:
+    def test_appends_date_to_bare_url(self):
+        base = 'https://www.gocomics.com/profile/User52732/comics/221821'
+        assert page_url_for_date(base, '2026-07-08') == base + '?date=2026-07-08'
+
+    def test_appends_date_with_ampersand_when_query_present(self):
+        base = 'https://www.gocomics.com/profile/User52732/comics/221821?foo=bar'
+        assert page_url_for_date(base, '2026-07-08') == base + '&date=2026-07-08'
+
+    def test_leaves_base_url_otherwise_unchanged(self):
+        base = 'https://www.gocomics.com/profile/User52732/comics/221821'
+        result = page_url_for_date(base, '2026-07-08')
+        # Everything up to the appended query is byte-identical to the base.
+        assert result.startswith(base)
+        assert result[len(base):] == '?date=2026-07-08'
 
 
 class TestGetImageSrc:


### PR DESCRIPTION
Fixes #164 (Jack Ohman feed stale since Jul 2).

## Problem

GoComics political cartoonists who publish *after* our daily Pass 2 scrape (13:00 PT / 16:00 ET) — or on a next-day lag — were silently and **permanently** dropped from their feeds. The favorites page is reactive: a cartoonist only shows as "updated" once their strip has actually posted, and a slug missed on its publish date is never written to any `data/comics_<date>.json`, so the feed never recovers it.

This is the tail of #138 (Nick Anderson): the two-pass fix caught the mid-morning wave but not this later one. Diagnostic evidence (2026-07-08): `jackohman` and **10 other** political comics that published that day were missed by both passes; re-fetching `?date=2026-07-08` now shows them "updated" and our extractor pulls them cleanly — so it's a timing gap, not an extraction bug.

## Fix

Rolling backfill. Each daily run re-scrapes the political favorites page for the last `GOCOMICS_BACKFILL_DAYS` days (default 3) via `?date=`, which returns the settled state once a strip exists, and merges newly-appeared slugs into that day's file.

- **U1** `page_url_for_date()` — date-aware favorites URL (shared with the diagnostic's construction).
- **U2** `--backfill-days N` + `run_backfill()` / `backfill_target_dates()` in `authenticated_scraper_secure.py`. After the same-day scrape it re-fetches each past date (one login) and merges via the existing `merge_with_existing` (additive for new slugs, replacive for overlapping same-date ones). Returns the touched date files.
- **U3** `local_pass2_update.sh` runs it and — the load-bearing part — stages **every** touched date file (today + window) on **both** the happy-path commit and the push-conflict recovery, via an explicit enumerated date list (never a `comics_*.json` glob). Previously all three staging points hardcoded today's file, so backfilled JSON would regenerate into feeds but never commit, then get wiped by the next `git reset --hard origin/main`.
- **U4** Solution doc updated for #164; implementation plan added.

**Why 3 days is robust:** each past date is re-fetched on every subsequent in-window day, so within-window late settling is self-healing. Only lateness *exceeding* the window is missed; `GOCOMICS_BACKFILL_DAYS` widens it without code edits.

## Verification

- 14 new unit tests; **full suite 340 passed**, offline (live sources mocked).
- Live smoke test against GoComics: the backfill recovered Jack Ohman on Jul 7, 8, and 9, preserving all existing entries.
- Code review (correctness / reliability / maintainability): zero actionable findings.

## Note on the reporter's backlog

The reporter's missing strips go back to Jul 2 — older than the 3-day window. After this merges, a one-off wider `--backfill-days` run on `main` will recover the Jul 3–7 gap and commit the feed-data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)