### PR TITLE
fix: derive SSH preflight host from push remote

### DIFF
--- a/docs/solutions/logic-errors/ssh-preflight-tested-wrong-host.md
+++ b/docs/solutions/logic-errors/ssh-preflight-tested-wrong-host.md
@@ -1,0 +1,83 @@
+---
+title: Daily run aborted — SSH preflight tested the wrong GitHub host
+date: 2026-07-22
+category: logic-errors
+module: pipeline
+problem_type: bug
+component: local_master_update.sh
+severity: high
+applies_when:
+  - "The overnight master update logs 'GitHub SSH authentication failed - check SSH key and keychain' and aborts before scraping"
+  - "A day's data/*_$DATE.json files and feed commit are entirely missing (run aborted, not partial failure)"
+  - "`ssh -T github-comiccaster` succeeds interactively but the pipeline still reports SSH auth failure"
+tags: [ssh, git-remote, host-alias, launchd, preflight, deploy-key, pipeline-abort]
+stack: [bash, ssh, git]
+github_prs: [168]
+---
+
+## TL;DR
+
+`scripts/local_master_update.sh` aborted the entire 2026-07-22 run before Phase 1
+because its SSH preflight tested a **hardcoded `ssh -T git@github.com`** (after
+`ssh-add ~/.ssh/id_rsa`), but the repo actually pushes over a **dedicated host
+alias**: `origin = git@github-comiccaster:adamprime/comiccaster.git`. That alias's
+deploy key (`~/.ssh/comiccaster_deploy`) is named via `IdentityFile` +
+`IdentitiesOnly yes` in `~/.ssh/config`.
+
+The guard validated the wrong host. It only passed when the agent happened to hold
+an `id_rsa` authorized for this repo. Once the agent was empty (nothing loaded it,
+or a reboot cleared it), `git@github.com` fell through to defaults → `Permission
+denied (publickey)` → `exit 0` abort, **even though the real aliased push
+authenticates fine**.
+
+## Why it looked like a keychain problem
+
+The abort message says "check SSH key and keychain", which points at launchd not
+reaching the login keychain. That's a real, separate gotcha — but here it was a
+red herring. The tell: `ssh -T github-comiccaster` (the alias) succeeds even in a
+non-interactive shell with an **empty agent** (`ssh-add -l` → "no identities"),
+because the alias authenticates directly from the key file via `IdentityFile`, no
+agent required. Only the hardcoded `git@github.com` failed.
+
+## Diagnosis steps
+
+```bash
+git remote -v                       # origin uses git@github-comiccaster:...
+ssh -T git@github.com               # Permission denied (publickey)  <- what the guard tested
+ssh -T github-comiccaster           # successfully authenticated       <- what the push uses
+grep -iA6 'host github-comiccaster' ~/.ssh/config   # IdentityFile ~/.ssh/comiccaster_deploy
+```
+
+## Fix (PR #168)
+
+Derive the SSH host from the push remote so the guard can never drift from what
+the push uses, and drop the stale `id_rsa` agent load:
+
+```bash
+REMOTE_URL="$(git -C "$REPO_DIR" remote get-url origin 2>/dev/null)"
+SSH_HOST="$(echo "$REMOTE_URL" | sed -n 's/^git@\([^:]*\):.*/\1/p')"
+# ... abort if empty ...
+if ! ssh -T "$SSH_HOST" 2>&1 | grep -q "successfully authenticated"; then ...
+```
+
+Verified: the fixed guard **passes in a non-interactive shell with an empty agent**
+— the same class of environment where the old check failed.
+
+## Recovery
+
+Rerun the pipeline manually once SSH is confirmed healthy; it scrapes the current
+day and pushes normally:
+
+```bash
+bash scripts/local_master_update.sh > logs/manual_recovery_$(date +%Y-%m-%d).log 2>&1
+```
+
+7/22 was recovered this way (commit `9c0650f81`, all 8 sources, ALL SUCCESS).
+
+## Gotcha for future manual reruns
+
+The pipeline runs `git reset --hard origin/main` near the top (Phase 0 sync). Any
+**uncommitted** working-tree edit — including a fix to this very script — is wiped
+by that reset. Commit script changes before relying on them in a run, or expect
+the reset to revert them mid-run (bash keeps executing the version it already read
+past the guard, but the file on disk reverts).

--- a/scripts/local_master_update.sh
+++ b/scripts/local_master_update.sh
@@ -38,12 +38,25 @@ source "$REPO_DIR/venv/bin/activate"
 # Install comiccaster package in editable mode (if not already installed)
 pip install -e "$REPO_DIR" > /dev/null 2>&1 || true
 
-# Load SSH key from Keychain (required for LaunchD which runs without GUI session)
-ssh-add --apple-use-keychain ~/.ssh/id_rsa 2>/dev/null || true
-
-# Verify GitHub SSH access before proceeding
-if ! ssh -T git@github.com 2>&1 | grep -q "successfully authenticated"; then
-    echo "❌ GitHub SSH authentication failed - check SSH key and keychain"
+# Verify GitHub SSH access before proceeding.
+# Derive the SSH host from the actual push remote so this check can never drift
+# from what the push uses. The remote uses a dedicated host alias
+# (git@github-comiccaster:...) whose deploy key is named via IdentityFile in
+# ~/.ssh/config, so no ssh-agent/keychain load is required. Testing a hardcoded
+# git@github.com here was a false-negative source: it validated the wrong host
+# and aborted the whole run even though the aliased push would have succeeded.
+REMOTE_URL="$(git -C "$REPO_DIR" remote get-url origin 2>/dev/null)"
+SSH_HOST="$(echo "$REMOTE_URL" | sed -n 's/^git@\([^:]*\):.*/\1/p')"
+if [ -z "$SSH_HOST" ]; then
+    echo "❌ Could not determine SSH host from origin remote: '$REMOTE_URL'"
+    echo "Aborting: Cannot push without a resolvable SSH remote."
+    echo "================================================================================"
+    echo "ComicCaster Master Update ABORTED (SSH) - $(date)"
+    echo "================================================================================"
+    exit 0
+fi
+if ! ssh -T "$SSH_HOST" 2>&1 | grep -q "successfully authenticated"; then
+    echo "❌ GitHub SSH authentication failed ($SSH_HOST) - check SSH key and keychain"
     osascript -e 'display notification "SSH auth failed - check keychain" with title "ComicCaster: Error" sound name "Basso"' 2>/dev/null || true
     # This is fatal -- we can't push anything without SSH
     echo "Aborting: Cannot push without SSH access."


### PR DESCRIPTION
## What broke

The 2026-07-22 overnight run **aborted before scraping anything** — no `data/*_2026-07-22.json`, no feed commit. Log:

```
ComicCaster Master Update - Wed Jul 22 03:05:02 CDT 2026
❌ GitHub SSH authentication failed - check SSH key and keychain
Aborting: Cannot push without SSH access.
ComicCaster Master Update ABORTED (SSH) - Wed Jul 22 03:05:04 CDT 2026
```

## Root cause

The SSH preflight guard tested a hardcoded `ssh -T git@github.com` after loading `~/.ssh/id_rsa` into the agent. But the repo pushes over a dedicated host alias — `git@github-comiccaster:...` — whose deploy key (`comiccaster_deploy`) is named via `IdentityFile` in `~/.ssh/config`.

So the guard validated the **wrong host**. It only passed when the agent happened to hold an `id_rsa` authorized for this repo (as on 7/21). Once the agent was empty (7/22), `git@github.com` returned `Permission denied` and the whole run aborted `exit 0` — even though the *actual* aliased push authenticates fine (verified: `ssh -T github-comiccaster` → success).

## Fix

- Derive the SSH host from `git remote get-url origin`, so the guard can never drift from what the push uses.
- Drop the stale `ssh-add ~/.ssh/id_rsa` — the alias authenticates directly via `IdentityFile`, no agent/keychain load needed.
- Abort with a clear message if the remote host can't be resolved.

Verified the fixed guard **passes in a non-interactive shell** (same class of env as launchd) where the old check failed.

## Recovery

7/22 feeds were already recovered by a manual run (commit `9c0650f81`, all 8 sources, pushed live) — this PR only prevents the guard from misfiring again.

## Tests

`pytest -q` → **341 passed**. (Bash orchestrator has no unit harness; guard behavior verified manually in the failing environment.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)