### PR TITLE
fix: derive SSH preflight host from push remote in pass2 too

### DIFF
--- a/scripts/local_pass2_update.sh
+++ b/scripts/local_pass2_update.sh
@@ -45,11 +45,22 @@ fi
 source "$REPO_DIR/venv/bin/activate"
 pip install -e "$REPO_DIR" > /dev/null 2>&1 || true
 
-# Load SSH key from Keychain (LaunchD runs without GUI session)
-ssh-add --apple-use-keychain ~/.ssh/id_rsa 2>/dev/null || true
-
-if ! ssh -T git@github.com 2>&1 | grep -q "successfully authenticated"; then
-    echo "❌ GitHub SSH authentication failed - check SSH key and keychain"
+# Verify GitHub SSH access before proceeding. Derive the SSH host from the actual
+# push remote so this check can never drift from what the push uses. The remote
+# uses a dedicated host alias (git@github-comiccaster:...) whose deploy key is
+# named via IdentityFile in ~/.ssh/config, so no ssh-agent/keychain load is
+# required. Testing a hardcoded git@github.com here was a false-negative source:
+# it validated the wrong host and aborted the whole run even though the aliased
+# push would have succeeded. Mirrors the guard in local_master_update.sh.
+REMOTE_URL="$(git -C "$REPO_DIR" remote get-url origin 2>/dev/null)"
+SSH_HOST="$(echo "$REMOTE_URL" | sed -n 's/^git@\([^:]*\):.*/\1/p')"
+if [ -z "$SSH_HOST" ]; then
+    echo "❌ Could not determine SSH host from origin remote: '$REMOTE_URL'"
+    echo "Aborting: Cannot push without a resolvable SSH remote."
+    exit 0
+fi
+if ! ssh -T "$SSH_HOST" 2>&1 | grep -q "successfully authenticated"; then
+    echo "❌ GitHub SSH authentication failed ($SSH_HOST) - check SSH key and keychain"
     osascript -e 'display notification "Pass 2: SSH auth failed" with title "ComicCaster: Error" sound name "Basso"' 2>/dev/null || true
     echo "Aborting: Cannot push without SSH access."
     exit 0


### PR DESCRIPTION
## Why

Follow-up to #168. That PR fixed the SSH preflight in `local_master_update.sh`, but **`local_pass2_update.sh` carried its own duplicate** of the same stale guard:

```bash
ssh-add --apple-use-keychain ~/.ssh/id_rsa 2>/dev/null || true
if ! ssh -T git@github.com 2>&1 | grep -q "successfully authenticated"; then ...
```

The **pass2 launchd job runs at 1:00 PM daily** (`mini_master_pass2.sh` → `local_pass2_update.sh`), so it would still abort before scraping whenever the ssh-agent didn't hold an authorized `id_rsa` — the identical failure that killed the 2026-07-22 morning run. The `GIT_SSH_COMMAND` set by the mini wrapper doesn't save it: that only affects git's own SSH, not the bare `ssh -T` preflight.

## Fix

Apply the same fix as #168 — derive the SSH host from `git remote get-url origin` and test that alias, so the guard matches the host the push actually uses (`git@github-comiccaster:...`, deploy key via `IdentityFile`).

Verified the fixed guard **passes in a non-interactive shell with an empty agent** (`ssh-add -l` → no identities) — the env where the old check failed.

## Scope check

Confirmed the other two scheduled paths are already covered:
- `master` (3:05 AM) → `local_master_update.sh` — fixed in #168
- `catchup` (`RunAtLoad`) → `mini_master_update.sh` → `local_master_update.sh` — inherits #168, no own guard

pass2 was the last remaining copy.

## Tests

`pytest -q` → **341 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)