### PR TITLE
feat: open GitHub issues when a pipeline scrape fails

### DIFF
--- a/.github/workflows/pipeline-alert.yml
+++ b/.github/workflows/pipeline-alert.yml
@@ -1,0 +1,69 @@
+name: Pipeline Alert
+
+# Opens/updates/closes GitHub issues for daily pipeline failures.
+#
+# The pipeline host detects failures, but it must not create the issues itself:
+# the Mini's `gh` is authenticated as the repo owner, and GitHub sends no
+# notification for an issue you author yourself. Host-created alerts were
+# therefore invisible to the one person meant to act on them -- verified
+# empirically, see docs/solutions/best-practices/.
+#
+# Dispatching here instead means issues are authored by github-actions[bot], a
+# different actor, so watching the repo produces a real notification and email.
+#
+# This is a direct API call from the host, not a git push, so it still fires
+# when pushing is the thing that is broken.
+
+on:
+  workflow_dispatch:
+    inputs:
+      run:
+        description: 'Which run reported this (pass1, pass2, preflight)'
+        required: true
+      date:
+        description: 'Run date, YYYY-MM-DD'
+        required: true
+      covered:
+        description: 'Comma-separated slugs this run actually examined'
+        required: true
+      failed:
+        description: 'Comma-separated slug:kind entries that failed'
+        required: false
+        default: ''
+      detail:
+        description: 'Extra context for the issue body (no secrets)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      # Every input is bound through env rather than interpolated into the run
+      # script, so no input value can be parsed as shell.
+      - name: Report pipeline failures
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_NAME: ${{ inputs.run }}
+          RUN_DATE: ${{ inputs.date }}
+          COVERED: ${{ inputs.covered }}
+          FAILED: ${{ inputs.failed }}
+          DETAIL: ${{ inputs.detail }}
+        run: |
+          python scripts/report_pipeline_failures.py \
+            --run "$RUN_NAME" \
+            --date "$RUN_DATE" \
+            --covered "$COVERED" \
+            --failed "$FAILED" \
+            --detail "$DETAIL"

--- a/docs/plans/2026-07-27-001-feat-pipeline-failure-github-issues-plan.md
+++ b/docs/plans/2026-07-27-001-feat-pipeline-failure-github-issues-plan.md
@@ -1,0 +1,201 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+title: "feat: Open GitHub issues when a pipeline scrape fails"
+date: 2026-07-27
+type: feat
+depth: standard
+github_issues: []
+related_docs:
+  - docs/LOCAL_AUTOMATION_README.md
+  - scripts/watch_feedback.py
+---
+
+# feat: Open GitHub issues when a pipeline scrape fails
+
+## Summary
+
+The twice-daily feed pipeline currently reports failures to two places only: the log
+file (`logs/master_update.log`, `logs/pass2_update.log`) and a macOS desktop
+notification via `osascript`. Both runs are unattended — Pass 1 at 03:05 and Pass 2 at
+13:00 — so a "Basso"-sound notification on the Mac Mini is effectively invisible. A
+source can break and stay broken until someone happens to read a log.
+
+This plan adds a **durable, remote alert**: when a content scrape (or the invariant
+guard, or the git push, or the SSH preflight) fails, the pipeline opens a GitHub issue
+on `adamprime/comiccaster`. Recurrences comment on the existing issue rather than
+opening duplicates, and the issue **auto-closes** when that source next succeeds.
+
+---
+
+## Problem Frame
+
+`local_master_update.sh` is deliberately fail-soft: individual step failures do not
+abort the run. Every step is an exit-code check that appends a human-readable string
+to a bash array:
+
+```bash
+if python scripts/scrape_creators.py; then
+    echo "✅ ..."
+else
+    echo "❌ Creators scraping failed"
+    FAILURES+=("Creators scraping")
+fi
+```
+
+At the end (`local_master_update.sh:369-381`) the array's length decides between a
+success notification and a failure notification, then the script always `exit 0` so
+LaunchD never retries.
+
+That array is the **only** in-memory record of what broke, and it dies with the
+process. There is no external signal.
+
+### Why not do this in CI
+
+The obvious alternative — have the host write a failure manifest and let a GitHub
+Action open the issue, keeping credentials in CI — has a disqualifying blind spot:
+**if the failure is the `git push` itself, the manifest never reaches GitHub.** The
+alerts you most need are exactly the ones that approach drops. Detection and alerting
+both belong on the host.
+
+### Why this is cheap
+
+`gh` 2.90.0 is already installed at `/opt/homebrew/bin/gh` and authenticated
+(account `adamprime`, keyring, scopes include `repo`). `mini_master_update.sh:17`
+already puts `/opt/homebrew/bin` on the LaunchAgent's `PATH`. **No new secret needs to
+be provisioned.**
+
+---
+
+## Design
+
+### Split: bash detects, Python reports
+
+The host runs **bash 3.2** (no associative arrays), and the repo's testing standard is
+pytest with mocked externals. So the state machine lives in Python, where it can be
+unit-tested, and bash only collects slugs and shells out.
+
+`scripts/watch_feedback.py` is the precedent to mirror: a `gh(*args)` subprocess
+helper, an `ensure_label()` that creates a colored label on demand, and idempotency by
+scanning existing issue bodies for a marker line.
+
+### 1. Bash: a machine-readable channel alongside the human one
+
+`FAILURES` stays exactly as-is — it still drives the log summary and the desktop
+notification. A parallel `FAILED_KEYS` array carries stable `<source>:<kind>` slugs,
+appended **only** at the in-scope sites:
+
+```bash
+FAILURES+=("TinyView scraping")     ; FAILED_KEYS+=("tinyview:scrape")
+FAILURES+=("$source invariant (…)") ; FAILED_KEYS+=("$slug:invariant")
+FAILURES+=("Git push")              ; FAILED_KEYS+=("push:push")
+```
+
+Feed-generation and `git fetch` failures are **out of scope** — they stay in
+`FAILURES` (log + notification) but do not open issues.
+
+Source slugs: `gocomics`, `comicskingdom`, `tinyview`, `newyorker`, `farside`,
+`creators`, `mrboffo`, plus the pseudo-sources `push` and `preflight`.
+
+### 2. Python: `scripts/report_pipeline_failures.py`
+
+```
+python scripts/report_pipeline_failures.py \
+    --run pass1 --date "$DATE_STR" \
+    --covered gocomics,comicskingdom,tinyview,newyorker,farside,creators,mrboffo,push \
+    --failed "gocomics:scrape,tinyview:invariant"
+```
+
+For each source in `--covered`:
+
+| state | action |
+|---|---|
+| in `--failed`, no open issue | **open** an issue |
+| in `--failed`, open issue exists | **comment** on it |
+| not in `--failed`, open issue exists | **comment + close** it (recovered) |
+| not in `--failed`, no open issue | nothing |
+
+Idempotency marker in the issue body, mirroring `watch_feedback.py`'s `Source: `:
+
+```
+Pipeline-Failure-Key: tinyview
+```
+
+Label `pipeline-failure`, created on demand. Title `[pipeline] TinyView scrape failed`.
+Body carries date, run, failure kind, and a tail of the run log for triage.
+
+### 3. `--covered` is the safety-critical part
+
+Pass 2 is **GoComics-only**. It must pass `--covered gocomics,push`. Without that
+scoping the 13:00 run would auto-close an open Comics Kingdom issue merely because CK
+wasn't in its failure list — CK isn't healthy, it simply wasn't examined.
+
+This also buys a good property: a GoComics failure at 03:05 that Pass 2 repairs at
+13:00 closes its own issue.
+
+### 4. The SSH preflight gap
+
+Both scripts abort at `local_master_update.sh:58-67` with `exit 0` when SSH auth
+fails — *before any scraping runs*. Under a naive design that produces **zero issues**
+on the run that failed hardest. This has bitten the project before (the
+`github-comiccaster` alias bug, PR #168).
+
+So the preflight abort branch also fires the reporter, with
+`--covered preflight --failed preflight:ssh`, before exiting.
+
+### 5. Failure isolation
+
+The reporter call is wrapped so that a `gh` outage can never break the pipeline:
+
+```bash
+python scripts/report_pipeline_failures.py ... || true
+```
+
+The reporter itself catches `gh` errors per-source, logs them, and continues.
+
+---
+
+## Decisions Taken
+
+- **Host-side, direct** over host-manifest-plus-CI — survives push failures; auth
+  already exists on the host.
+- **Scope: scrape + invariant + push (+ preflight)** — generation and `git fetch`
+  failures remain log-only.
+- **Per-source issues with comment-on-recurrence and auto-close** over a daily rollup
+  issue — individually triageable and self-clearing.
+- **No consecutive-failure threshold.** Known-flaky sources (TinyView lapses; Comics
+  Kingdom sessions expiring ~every 10 days) will open issues on first failure. Accepted
+  deliberately: the per-run comment trail on a long-running issue is the outage-duration
+  record that would otherwise have to be reconstructed from logs.
+
+## Risks
+
+- **Keychain under launchd.** `gh` reads its token from the macOS keyring. LaunchAgents
+  run in the Aqua session and the CK scraper already requires an active GUI login, so
+  this should work — but it must be *verified* in a launchd context, not assumed.
+  Fallback if it fails: a `GH_TOKEN` in `.env`, which the script already exports.
+- **Comment volume.** A 10-day CK outage yields ~10 comments on one open issue.
+  Accepted (see above).
+
+## Test Plan
+
+`tests/test_report_pipeline_failures.py`, with the `gh` subprocess mocked — no network,
+no real issues:
+
+- opens an issue for a failing source with no existing open issue
+- comments (does **not** re-open) when an open issue already carries the marker
+- comments and closes when a previously-failing source is healthy
+- **never touches a source outside `--covered`** (the Pass 2 regression guard)
+- creates the `pipeline-failure` label only when absent
+- parses `--failed` slugs into source + kind, tolerating empty input
+- a `gh` error on one source does not abort the remaining sources
+
+## Rollout
+
+1. Tests, then reporter script, then bash wiring (TDD).
+2. `pytest -v` green before commit — `main` auto-deploys.
+3. Verify `gh` from a launchd-context invocation.
+4. Force a synthetic failure (e.g. a bogus slug) to confirm open → comment → close
+   end-to-end, then close the test issue.

--- a/docs/plans/2026-07-27-001-feat-pipeline-failure-github-issues-plan.md
+++ b/docs/plans/2026-07-27-001-feat-pipeline-failure-github-issues-plan.md
@@ -63,9 +63,23 @@ both belong on the host.
 ### Why this is cheap
 
 `gh` 2.90.0 is already installed at `/opt/homebrew/bin/gh` and authenticated
-(account `adamprime`, keyring, scopes include `repo`). `mini_master_update.sh:17`
-already puts `/opt/homebrew/bin` on the LaunchAgent's `PATH`. **No new secret needs to
-be provisioned.**
+(account `adamprime`, keyring, scopes include `repo` and `workflow`).
+`mini_master_update.sh:17` already puts `/opt/homebrew/bin` on the LaunchAgent's
+`PATH`. **No new secret needs to be provisioned.**
+
+### Correction during implementation: the host must not author the issues
+
+The first implementation had the host create issues directly. It worked, and it was
+useless: **GitHub sends no notification for an issue you author yourself**, and the
+Mini authenticates as the repo owner. Alerts were invisible to the one person meant
+to act on them — confirmed by opening a real issue and getting no email, and by an
+empty notification inbox.
+
+The host therefore *detects* and *dispatches*; GitHub Actions *creates*, so issues
+are authored by `github-actions[bot]` and notify normally. `gh workflow run` is a
+direct API call rather than a `git push`, so the push-failure robustness above is
+preserved. Full write-up:
+`docs/solutions/best-practices/github-self-authored-issues-dont-notify.md`.
 
 ---
 
@@ -99,14 +113,20 @@ Feed-generation and `git fetch` failures are **out of scope** — they stay in
 Source slugs: `gocomics`, `comicskingdom`, `tinyview`, `newyorker`, `farside`,
 `creators`, `mrboffo`, plus the pseudo-sources `push` and `preflight`.
 
-### 2. Python: `scripts/report_pipeline_failures.py`
+### 2. Python: `scripts/report_pipeline_failures.py`, run from Actions
 
+The host dispatches:
+
+```bash
+gh workflow run pipeline-alert.yml \
+    --field run=pass1 --field date="$DATE_STR" \
+    --field covered="$ALERT_COVERED" \
+    --field failed="gocomics:scrape,tinyview:invariant" || true
 ```
-python scripts/report_pipeline_failures.py \
-    --run pass1 --date "$DATE_STR" \
-    --covered gocomics,comicskingdom,tinyview,newyorker,farside,creators,mrboffo,push \
-    --failed "gocomics:scrape,tinyview:invariant"
-```
+
+`.github/workflows/pipeline-alert.yml` then runs the reporter under
+`GITHUB_TOKEN`. All dispatch inputs are bound through `env:` rather than
+interpolated into the `run:` script, so no input can be parsed as shell.
 
 For each source in `--covered`:
 
@@ -124,7 +144,9 @@ Pipeline-Failure-Key: tinyview
 ```
 
 Label `pipeline-failure`, created on demand. Title `[pipeline] TinyView scrape failed`.
-Body carries date, run, failure kind, and a tail of the run log for triage.
+Body carries date, run, and failure kind — **no run-log excerpt**: this repo is
+public and pipeline logs can carry account emails and cookie paths. The operator
+reads the real log on the host.
 
 ### 3. `--covered` is the safety-critical part
 

--- a/docs/solutions/best-practices/github-self-authored-issues-dont-notify.md
+++ b/docs/solutions/best-practices/github-self-authored-issues-dont-notify.md
@@ -1,0 +1,104 @@
+---
+title: Alerting via GitHub issues — you get no notification for issues you author
+date: 2026-07-27
+category: best-practices
+module: pipeline
+problem_type: best-practice
+component: scripts/report_pipeline_failures.py
+severity: high
+applies_when:
+  - "An automated alert opens a GitHub issue but no email or notification ever arrives"
+  - "Deciding which identity a bot/automation should authenticate as"
+  - "An alert issue is visible in the web UI but absent from the notification inbox"
+tags: [github, notifications, alerting, gh-cli, github-actions, automation-identity]
+stack: [gh-cli, github-actions]
+---
+
+## Problem
+
+The pipeline failure reporter opened GitHub issues correctly from the Mac Mini,
+using the `gh` CLI authenticated as `adamprime` — the repo owner. The issues
+appeared in the web UI exactly as intended.
+
+**No email ever arrived. No notification was generated at all.**
+
+The whole point of the feature was to catch an overnight failure by morning. It
+was inert: the alerts existed, but reached nobody.
+
+## Root cause
+
+**GitHub does not notify you about your own activity.** An issue you author
+generates no notification for you — not in the notification inbox, and therefore
+not by email. The Mini authenticated as the repo owner, so every alert it created
+was, from GitHub's perspective, the owner talking to themselves.
+
+Verified empirically:
+
+```
+$ gh issue view 174 --json author --jq '.author.login'
+adamprime
+
+$ gh api "/notifications?all=true" --jq '.[] | select(.subject.title | test("TEST"))'
+(nothing — no inbox entry at all)
+```
+
+Two things this is **not**:
+
+- Not an email-settings problem. No notification was generated, so there was
+  nothing for email delivery to deliver.
+- Not fixable with a self-`@mention`. Tested directly: an issue body containing
+  `@adamprime`, authored by `adamprime`, still produced nothing after 45s. The
+  `mention` reason requires a *different* actor to mention you.
+
+The contrast that revealed the fix, from the same notification inbox:
+
+| notification | author | reason | arrives? |
+|---|---|---|---|
+| pipeline alert issue | `adamprime` (you) | — | **no** |
+| `[feedback-site]` issue | `app/github-actions` | subscribed | yes |
+| Dependabot PR | `dependabot` | subscribed | yes |
+
+## Fix
+
+**Make the automation act as a different identity.** The alert workflow moved to
+GitHub Actions, where `GITHUB_TOKEN` authors issues as `github-actions[bot]`.
+Watching the repo then produces a normal `subscribed` notification and an email.
+
+The host still *detects* failures — it just dispatches instead of creating:
+
+```bash
+gh workflow run pipeline-alert.yml \
+    --field run=pass1 \
+    --field covered="$covered" \
+    --field failed="$failed" || true
+```
+
+This preserves the property that motivated host-side detection in the first
+place: `gh workflow run` is a direct API call, **not** a `git push`, so it still
+fires when pushing is exactly what is broken.
+
+The alternative — enabling "Include your own updates" at
+github.com/settings/notifications — also works, but it is account-wide and emails
+you for all of your own activity in every repo. Rejected as too noisy for a fix
+that belongs to one automation.
+
+## Related: don't put log tails in public issues
+
+While rerouting, the issue body stopped embedding a 40-line run-log excerpt.
+This repo is **public**, and pipeline logs can carry account emails, cookie
+paths, and scraper internals. Issues now carry structured facts only (source,
+failure kind, run, date); the operator reads the real log on the host.
+
+## Lesson
+
+**An alerting system's deliverable is the notification, not the record.** A
+correct, well-tested, idempotent issue that reaches nobody is a failure of the
+feature, however green the tests are.
+
+When automation acts on your behalf, ask *who the actor is* — platforms
+routinely suppress self-notifications, so automation authenticating as the
+person it is meant to alert is a silent dead end. Give the bot its own identity.
+
+And verify delivery end-to-end, with a human confirming receipt. No unit test
+and no API assertion would have caught this; it took opening a real issue and
+asking "did you get an email?"

--- a/docs/solutions/logic-errors/github-issue-list-label-eventual-consistency.md
+++ b/docs/solutions/logic-errors/github-issue-list-label-eventual-consistency.md
@@ -1,0 +1,77 @@
+---
+title: Duplicate alert issues — label-filtered `gh issue list` is eventually consistent
+date: 2026-07-27
+category: logic-errors
+module: pipeline
+problem_type: bug
+component: scripts/report_pipeline_failures.py
+severity: medium
+applies_when:
+  - "An idempotent script creates a GitHub issue then re-queries for it moments later and doesn't find it"
+  - "Two identical `[pipeline] … failed` issues exist for the same source"
+  - "`gh issue list --label X --state open` returns [] for an issue you can see in the web UI"
+tags: [github, gh-cli, idempotency, eventual-consistency, alerting, duplicates]
+stack: [python, gh-cli]
+---
+
+## Problem
+
+`report_pipeline_failures.py` is supposed to open **one** issue per failing source
+and comment on it thereafter. During end-to-end testing, two back-to-back runs with
+the same failure opened **two** issues (#171 and #172) instead of open-then-comment.
+
+The dedupe lookup was:
+
+```python
+gh("issue", "list", "--label", LABEL, "--state", "open", "--limit", "200",
+   "--json", "number,body")
+```
+
+which returned `[]` — even though the issue had just been created successfully
+*with* that label, and was visible via `gh issue list` with no label filter.
+
+## Root cause
+
+**GitHub's label-filtered issue listing is eventually consistent.** For roughly a
+minute after an issue is created, it can be absent from a `--label`-filtered query
+while already present in an unfiltered one. The reporter therefore concluded "no
+open issue exists for this source" and opened a duplicate.
+
+This was not a bug in the marker/dedupe logic — the `Pipeline-Failure-Key:` marker
+scan worked correctly. It never got the chance to run, because the *input list* was
+empty.
+
+## Fix
+
+Stop depending on the label for lookup. The body marker is already the
+authoritative identifier, so query open issues unfiltered and match on the marker:
+
+```python
+gh("issue", "list", "--state", "open", "--limit", "200", "--json", "number,body")
+```
+
+The `pipeline-failure` label is still applied on creation — it is for humans
+filtering the issue tracker, not for machine identity.
+
+Also made duplicate resolution deterministic: if two open issues somehow carry the
+same marker, the **oldest** (lowest number) wins, so repeated runs converge on one
+issue instead of alternating between them. A subsequent recovery run closes the
+stragglers one per run.
+
+## Why it barely mattered in production (and was still worth fixing)
+
+Pass 1 runs at 03:05 and Pass 2 at 13:00 — ten hours apart, far beyond the
+consistency window. The duplicate only reproduced because the test fired both runs
+within seconds. But the same-run window matters for any future retry or catch-up
+path, and the unfiltered query is strictly more robust at no cost.
+
+## Lesson
+
+When building idempotency on top of a remote API, **identify records by data you
+control (a marker in the body), and fetch them by the most strongly-consistent
+query available.** A server-side filter that is merely convenient can silently
+return a stale empty set and turn "check before create" into "create every time."
+
+Unit tests with a mocked `gh` could not have caught this — the mock answered label
+queries perfectly. It took a real end-to-end run against GitHub. Keep an
+end-to-end verification step for anything whose whole purpose is idempotency.

--- a/scripts/local_master_update.sh
+++ b/scripts/local_master_update.sh
@@ -24,8 +24,18 @@ echo "==========================================================================
 echo "ComicCaster Master Update - $(date)"
 echo "================================================================================"
 
-# Track failures
+# Track failures. FAILURES holds human-readable labels for the log summary and
+# the desktop notification; FAILED_KEYS holds stable "<slug>:<kind>" slugs for
+# the GitHub issue reporter. Only scrape, invariant, and push failures get a
+# slug -- feed generation and git fetch stay log-only by design.
 FAILURES=()
+FAILED_KEYS=()
+
+# Sources this run examines, so the reporter knows what it may auto-close.
+# Pass 1 covers everything; Pass 2 covers GoComics only.
+# `preflight` is included because reaching the end of a run proves it passed,
+# which is what auto-closes a preflight issue from a previous run.
+ALERT_COVERED="gocomics,comicskingdom,tinyview,newyorker,farside,creators,mrboffo,push,preflight"
 
 # Load environment variables (.env has GoComics credentials)
 if [ -f "$REPO_DIR/.env" ]; then
@@ -37,6 +47,18 @@ source "$REPO_DIR/venv/bin/activate"
 
 # Install comiccaster package in editable mode (if not already installed)
 pip install -e "$REPO_DIR" > /dev/null 2>&1 || true
+
+# Open/update/close GitHub issues for this run's failures. Best-effort: a gh
+# outage must never break the pipeline, hence the trailing `|| true`.
+report_pipeline_failures() {
+    local covered="$1" failed="$2"
+    python "$REPO_DIR/scripts/report_pipeline_failures.py" \
+        --run pass1 \
+        --date "$(date +%Y-%m-%d)" \
+        --covered "$covered" \
+        --failed "$failed" \
+        --log-file "$LOG_FILE" || true
+}
 
 # Verify GitHub SSH access before proceeding.
 # Derive the SSH host from the actual push remote so this check can never drift
@@ -50,6 +72,9 @@ SSH_HOST="$(echo "$REMOTE_URL" | sed -n 's/^git@\([^:]*\):.*/\1/p')"
 if [ -z "$SSH_HOST" ]; then
     echo "❌ Could not determine SSH host from origin remote: '$REMOTE_URL'"
     echo "Aborting: Cannot push without a resolvable SSH remote."
+    # This aborts before any scraping, so the normal end-of-run report never
+    # happens. Alert here or the hardest failure is the quietest one.
+    report_pipeline_failures "preflight" "preflight:remote"
     echo "================================================================================"
     echo "ComicCaster Master Update ABORTED (SSH) - $(date)"
     echo "================================================================================"
@@ -60,6 +85,9 @@ if ! ssh -T "$SSH_HOST" 2>&1 | grep -q "successfully authenticated"; then
     osascript -e 'display notification "SSH auth failed - check keychain" with title "ComicCaster: Error" sound name "Basso"' 2>/dev/null || true
     # This is fatal -- we can't push anything without SSH
     echo "Aborting: Cannot push without SSH access."
+    # Aborts before any scraping, so alert here (see PR #168 -- a preflight bug
+    # silently killed daily runs).
+    report_pipeline_failures "preflight" "preflight:ssh"
     echo "================================================================================"
     echo "ComicCaster Master Update ABORTED (SSH) - $(date)"
     echo "================================================================================"
@@ -94,6 +122,7 @@ if python scripts/authenticated_scraper_secure.py --output-dir ./data; then
 else
     echo "❌ GoComics scraping failed"
     FAILURES+=("GoComics scraping")
+    FAILED_KEYS+=("gocomics:scrape")
 fi
 
 echo ""
@@ -106,6 +135,7 @@ if python scripts/comicskingdom_scraper_individual.py ${CK_SCRAPER_EXTRA_ARGS:-}
 else
     echo "❌ Comics Kingdom scraping failed"
     FAILURES+=("Comics Kingdom scraping")
+    FAILED_KEYS+=("comicskingdom:scrape")
 fi
 
 echo ""
@@ -115,6 +145,7 @@ if python scripts/tinyview_scraper_local_authenticated.py --date "$DATE_STR" --d
 else
     echo "❌ TinyView scraping failed"
     FAILURES+=("TinyView scraping")
+    FAILED_KEYS+=("tinyview:scrape")
 fi
 
 echo ""
@@ -124,6 +155,7 @@ if python scripts/scrape_farside.py; then
 else
     echo "❌ Far Side scraping failed"
     FAILURES+=("Far Side scraping")
+    FAILED_KEYS+=("farside:scrape")
 fi
 
 echo ""
@@ -133,6 +165,7 @@ if python scripts/scrape_newyorker.py; then
 else
     echo "❌ New Yorker scraping failed"
     FAILURES+=("New Yorker scraping")
+    FAILED_KEYS+=("newyorker:scrape")
 fi
 
 echo ""
@@ -142,6 +175,7 @@ if python scripts/scrape_creators.py; then
 else
     echo "❌ Creators scraping failed"
     FAILURES+=("Creators scraping")
+    FAILED_KEYS+=("creators:scrape")
 fi
 
 echo ""
@@ -151,6 +185,7 @@ if python scripts/scrape_mrboffo.py; then
 else
     echo "❌ Mr. Boffo scraping failed"
     FAILURES+=("Mr. Boffo scraping")
+    FAILED_KEYS+=("mrboffo:scrape")
 fi
 
 # Phase 2: Generate all feeds from scraped data
@@ -228,7 +263,7 @@ fi
 echo ""
 echo "=== Verifying scrape invariants ==="
 check_scrape_output() {
-    local source="$1" file="$2"
+    local source="$1" slug="$2" file="$3"
     # Skip the check if this source's scraping was already reported as failed.
     if [ ${#FAILURES[@]} -gt 0 ] && printf '%s\n' "${FAILURES[@]}" | grep -qxF "$source scraping"; then
         return 0
@@ -236,18 +271,20 @@ check_scrape_output() {
     if [ ! -f "$file" ]; then
         echo "❌ Invariant violation: $source scrape reported success but $file is missing"
         FAILURES+=("$source invariant ($(basename "$file") missing)")
+        # Far Side is checked twice; a duplicate slug collapses to one issue.
+        FAILED_KEYS+=("$slug:invariant")
     else
         echo "✅ $source: $(basename "$file") present"
     fi
 }
-check_scrape_output "GoComics"       "data/comics_$DATE_STR.json"
-check_scrape_output "Comics Kingdom" "data/comicskingdom_$DATE_STR.json"
-check_scrape_output "TinyView"       "data/tinyview_$DATE_STR.json"
-check_scrape_output "New Yorker"     "data/newyorker_$DATE_STR.json"
-check_scrape_output "Far Side"       "data/farside_daily_$DATE_STR.json"
-check_scrape_output "Far Side"       "data/farside_new_$DATE_STR.json"
-check_scrape_output "Creators"       "data/creators_$DATE_STR.json"
-check_scrape_output "Mr. Boffo"      "data/mrboffo_$DATE_STR.json"
+check_scrape_output "GoComics"       "gocomics"      "data/comics_$DATE_STR.json"
+check_scrape_output "Comics Kingdom" "comicskingdom" "data/comicskingdom_$DATE_STR.json"
+check_scrape_output "TinyView"       "tinyview"      "data/tinyview_$DATE_STR.json"
+check_scrape_output "New Yorker"     "newyorker"     "data/newyorker_$DATE_STR.json"
+check_scrape_output "Far Side"       "farside"       "data/farside_daily_$DATE_STR.json"
+check_scrape_output "Far Side"       "farside"       "data/farside_new_$DATE_STR.json"
+check_scrape_output "Creators"       "creators"      "data/creators_$DATE_STR.json"
+check_scrape_output "Mr. Boffo"      "mrboffo"       "data/mrboffo_$DATE_STR.json"
 
 # Phase 3: Commit and push everything that succeeded.
 # Recovery on push rejection: save same-day scrape JSONs to a staging dir, reset
@@ -363,6 +400,7 @@ Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.g
 
     if [ "$PUSH_OK" = false ]; then
         FAILURES+=("Git push")
+        FAILED_KEYS+=("push:push")
     fi
 fi
 
@@ -378,6 +416,14 @@ else
     echo "Failed steps: $FAIL_LIST"
     osascript -e "display notification \"Failed: $FAIL_LIST\" with title \"ComicCaster: Partial Failure\" sound name \"Basso\"" 2>/dev/null || true
 fi
+
+# Reconcile GitHub issues. Runs on success too -- that is what closes an issue
+# for a source that has recovered.
+FAILED_KEY_LIST=""
+if [ ${#FAILED_KEYS[@]} -gt 0 ]; then
+    FAILED_KEY_LIST=$(IFS=,; echo "${FAILED_KEYS[*]}")
+fi
+report_pipeline_failures "$ALERT_COVERED" "$FAILED_KEY_LIST"
 echo "================================================================================"
 
 # Always exit 0 -- LaunchD should not retry on failure.

--- a/scripts/local_master_update.sh
+++ b/scripts/local_master_update.sh
@@ -48,16 +48,21 @@ source "$REPO_DIR/venv/bin/activate"
 # Install comiccaster package in editable mode (if not already installed)
 pip install -e "$REPO_DIR" > /dev/null 2>&1 || true
 
-# Open/update/close GitHub issues for this run's failures. Best-effort: a gh
-# outage must never break the pipeline, hence the trailing `|| true`.
+# Report this run's outcome by dispatching a GitHub Actions workflow rather than
+# creating issues here. The Mini's `gh` is authenticated as the repo owner, and
+# GitHub sends NO notification for an issue you author yourself -- host-created
+# alerts were silently invisible to the person meant to act on them. Dispatching
+# makes github-actions[bot] the author, which does notify.
+#
+# This is a direct API call, not a git push, so it still fires when pushing is
+# the thing that broke. Best-effort: never fatal to the pipeline.
 report_pipeline_failures() {
     local covered="$1" failed="$2"
-    python "$REPO_DIR/scripts/report_pipeline_failures.py" \
-        --run pass1 \
-        --date "$(date +%Y-%m-%d)" \
-        --covered "$covered" \
-        --failed "$failed" \
-        --log-file "$LOG_FILE" || true
+    gh workflow run pipeline-alert.yml \
+        --field run=pass1 \
+        --field date="$(date +%Y-%m-%d)" \
+        --field covered="$covered" \
+        --field failed="$failed" || true
 }
 
 # Verify GitHub SSH access before proceeding.

--- a/scripts/local_pass2_update.sh
+++ b/scripts/local_pass2_update.sh
@@ -52,15 +52,21 @@ fi
 source "$REPO_DIR/venv/bin/activate"
 pip install -e "$REPO_DIR" > /dev/null 2>&1 || true
 
-# Open/update/close GitHub issues for this run. Best-effort; never fatal.
+# Report this run's outcome by dispatching a GitHub Actions workflow rather than
+# creating issues here. The Mini's `gh` is authenticated as the repo owner, and
+# GitHub sends NO notification for an issue you author yourself -- host-created
+# alerts were silently invisible to the person meant to act on them. Dispatching
+# makes github-actions[bot] the author, which does notify.
+#
+# This is a direct API call, not a git push, so it still fires when pushing is
+# the thing that broke. Best-effort: never fatal to the pipeline.
 report_pipeline_failures() {
     local covered="$1" failed="$2"
-    python "$REPO_DIR/scripts/report_pipeline_failures.py" \
-        --run pass2 \
-        --date "$(date +%Y-%m-%d)" \
-        --covered "$covered" \
-        --failed "$failed" \
-        --log-file "$LOG_FILE" || true
+    gh workflow run pipeline-alert.yml \
+        --field run=pass2 \
+        --field date="$(date +%Y-%m-%d)" \
+        --field covered="$covered" \
+        --field failed="$failed" || true
 }
 
 # Verify GitHub SSH access before proceeding. Derive the SSH host from the actual

--- a/scripts/local_pass2_update.sh
+++ b/scripts/local_pass2_update.sh
@@ -36,6 +36,13 @@ echo "ComicCaster Pass 2 Update (GoComics only) - $(date)"
 echo "================================================================================"
 
 FAILURES=()
+# Stable "<slug>:<kind>" slugs for the GitHub issue reporter (see
+# local_master_update.sh for the full rationale).
+FAILED_KEYS=()
+
+# Pass 2 examines GoComics only. This list is what the reporter may auto-close,
+# so it must NOT name the other sources -- they are untouched here, not healthy.
+ALERT_COVERED="gocomics,push,preflight"
 
 # Load environment variables (.env has GoComics credentials)
 if [ -f "$REPO_DIR/.env" ]; then
@@ -44,6 +51,17 @@ fi
 
 source "$REPO_DIR/venv/bin/activate"
 pip install -e "$REPO_DIR" > /dev/null 2>&1 || true
+
+# Open/update/close GitHub issues for this run. Best-effort; never fatal.
+report_pipeline_failures() {
+    local covered="$1" failed="$2"
+    python "$REPO_DIR/scripts/report_pipeline_failures.py" \
+        --run pass2 \
+        --date "$(date +%Y-%m-%d)" \
+        --covered "$covered" \
+        --failed "$failed" \
+        --log-file "$LOG_FILE" || true
+}
 
 # Verify GitHub SSH access before proceeding. Derive the SSH host from the actual
 # push remote so this check can never drift from what the push uses. The remote
@@ -57,12 +75,15 @@ SSH_HOST="$(echo "$REMOTE_URL" | sed -n 's/^git@\([^:]*\):.*/\1/p')"
 if [ -z "$SSH_HOST" ]; then
     echo "❌ Could not determine SSH host from origin remote: '$REMOTE_URL'"
     echo "Aborting: Cannot push without a resolvable SSH remote."
+    # Aborts before any scraping, so the end-of-run report never happens.
+    report_pipeline_failures "preflight" "preflight:remote"
     exit 0
 fi
 if ! ssh -T "$SSH_HOST" 2>&1 | grep -q "successfully authenticated"; then
     echo "❌ GitHub SSH authentication failed ($SSH_HOST) - check SSH key and keychain"
     osascript -e 'display notification "Pass 2: SSH auth failed" with title "ComicCaster: Error" sound name "Basso"' 2>/dev/null || true
     echo "Aborting: Cannot push without SSH access."
+    report_pipeline_failures "preflight" "preflight:ssh"
     exit 0
 fi
 
@@ -114,6 +135,7 @@ if python scripts/authenticated_scraper_secure.py --output-dir ./data --merge --
 else
     echo "❌ GoComics pass-2 scrape failed"
     FAILURES+=("GoComics pass-2 scrape")
+    FAILED_KEYS+=("gocomics:scrape")
 fi
 
 # If the scrape failed but the existing file is intact, generator can still
@@ -206,6 +228,7 @@ pass-1 scrape. See docs/solutions/logic-errors/gocomics-favorites-page-timing.md
 
     if [ "$PUSH_OK" = false ]; then
         FAILURES+=("Git push")
+        FAILED_KEYS+=("push:push")
     fi
 fi
 
@@ -220,6 +243,14 @@ else
     echo "Failed steps: $FAIL_LIST"
     osascript -e "display notification \"Pass 2 failed: $FAIL_LIST\" with title \"ComicCaster: Pass 2 Failure\" sound name \"Basso\"" 2>/dev/null || true
 fi
+
+# Reconcile GitHub issues. Runs on success too, so a GoComics failure from the
+# 03:05 pass closes itself when this pass repairs it.
+FAILED_KEY_LIST=""
+if [ ${#FAILED_KEYS[@]} -gt 0 ]; then
+    FAILED_KEY_LIST=$(IFS=,; echo "${FAILED_KEYS[*]}")
+fi
+report_pipeline_failures "$ALERT_COVERED" "$FAILED_KEY_LIST"
 echo "================================================================================"
 
 # Always exit 0 — LaunchD should not retry on failure.

--- a/scripts/report_pipeline_failures.py
+++ b/scripts/report_pipeline_failures.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Open, update, and close GitHub issues for pipeline failures.
+
+The daily pipeline is unattended (03:05 and 13:00), so its macOS desktop
+notification is effectively invisible. This turns a failure into a durable,
+remote alert: one GitHub issue per failing source, identified by a
+"Pipeline-Failure-Key: <slug>" line in the issue body.
+
+State machine, evaluated per source in --covered:
+
+    failing, no open issue    -> open one
+    failing, open issue       -> comment on it
+    healthy, open issue       -> comment and close it
+    healthy, no open issue    -> nothing
+
+--covered is what makes this safe to run from both passes. Pass 2 scrapes
+GoComics only, so it covers only GoComics; without that scoping it would
+auto-close a Comics Kingdom issue merely because CK wasn't in its failure
+list -- CK isn't healthy, it simply wasn't examined.
+
+Uses the `gh` CLI, which is installed and authenticated on the pipeline host.
+Never raises into the pipeline: gh errors are logged and reported via exit
+code, and the caller invokes this with `|| true`.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+LABEL = "pipeline-failure"
+LABEL_COLOR = "b60205"
+MARKER_PREFIX = "Pipeline-Failure-Key: "
+LOG_TAIL_LINES = 40
+
+# Display names for the pipeline's stable slugs. `push` and `preflight` are
+# pseudo-sources: whole-run failures that aren't tied to one comic source.
+SOURCE_NAMES = {
+    "gocomics": "GoComics",
+    "comicskingdom": "Comics Kingdom",
+    "tinyview": "TinyView",
+    "newyorker": "New Yorker",
+    "farside": "Far Side",
+    "creators": "Creators",
+    "mrboffo": "Mr. Boffo",
+    "push": "Git push",
+    "preflight": "SSH preflight",
+}
+
+
+def gh(*args: str) -> str:
+    return subprocess.run(
+        ["gh", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def parse_failed(raw: str) -> dict:
+    """Parse "slug:kind,slug:kind" into {slug: kind}."""
+    failed = {}
+    for entry in (raw or "").split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        slug, _, kind = entry.partition(":")
+        failed[slug.strip()] = kind.strip() or "unknown"
+    return failed
+
+
+def parse_covered(raw: str) -> list:
+    return [s.strip() for s in (raw or "").split(",") if s.strip()]
+
+
+def display_name(slug: str) -> str:
+    return SOURCE_NAMES.get(slug, slug)
+
+
+def issue_title(slug: str, kind: str) -> str:
+    return f"[pipeline] {display_name(slug)} {kind} failed"
+
+
+def issue_body(slug: str, kind: str, run: str, date: str, log_tail: str) -> str:
+    body = (
+        f"The {run} pipeline run on {date} reported a **{kind}** failure for "
+        f"**{display_name(slug)}**.\n\n"
+        f"- Source: {display_name(slug)} (`{slug}`)\n"
+        f"- Failure: {kind}\n"
+        f"- Run: {run}\n"
+        f"- First seen: {date}\n\n"
+        "This issue closes itself automatically when this source next succeeds.\n"
+    )
+    if log_tail:
+        body += f"\n<details><summary>Log tail</summary>\n\n```\n{log_tail}\n```\n\n</details>\n"
+    body += f"\n{MARKER_PREFIX}{slug}\n"
+    return body
+
+
+def recurrence_comment(slug: str, kind: str, run: str, date: str, log_tail: str) -> str:
+    comment = (
+        f"Still failing: **{kind}** on the {run} run of {date}.\n"
+    )
+    if log_tail:
+        comment += f"\n<details><summary>Log tail</summary>\n\n```\n{log_tail}\n```\n\n</details>\n"
+    return comment
+
+
+def recovery_comment(slug: str, run: str, date: str) -> str:
+    return (
+        f"Recovered: {display_name(slug)} succeeded on the {run} run of {date}. "
+        "Closing automatically.\n"
+    )
+
+
+def ensure_label() -> None:
+    existing = json.loads(gh("label", "list", "--json", "name", "--limit", "200"))
+    if any(label["name"] == LABEL for label in existing):
+        return
+    gh(
+        "label", "create", LABEL,
+        "--description", "Automated feed pipeline failure",
+        "--color", LABEL_COLOR,
+    )
+
+
+def open_issues_by_key() -> dict:
+    """Map marker key -> issue number for every open pipeline-failure issue.
+
+    Deliberately does NOT filter by label: GitHub's label-filtered listing is
+    eventually consistent and can omit an issue for a minute or so after it is
+    created, which made a second run open a duplicate instead of commenting.
+    The body marker is the authoritative identifier, so we scan open issues and
+    match on that. The label stays purely for human filtering.
+
+    On the rare duplicate (same marker on two issues), the oldest wins so that
+    repeated runs converge on one issue instead of alternating.
+    """
+    issues = json.loads(
+        gh(
+            "issue", "list",
+            "--state", "open",
+            "--limit", "200",
+            "--json", "number,body",
+        )
+    )
+    found = {}
+    for issue in issues:
+        for line in (issue.get("body") or "").splitlines():
+            if line.startswith(MARKER_PREFIX):
+                key = line[len(MARKER_PREFIX):].strip()
+                number = issue["number"]
+                if key not in found or number < found[key]:
+                    found[key] = number
+    return found
+
+
+def read_log_tail(path: str) -> str:
+    if not path:
+        return ""
+    try:
+        with open(path, "r", errors="replace") as handle:
+            lines = handle.read().splitlines()
+    except OSError as exc:
+        print(f"could not read log file {path}: {exc}", file=sys.stderr)
+        return ""
+    return "\n".join(lines[-LOG_TAIL_LINES:])
+
+
+def report(covered, failed, run, date, log_tail="") -> int:
+    """Reconcile GitHub issues against this run's outcome.
+
+    Returns 0 if every source was reported successfully, 1 otherwise. Never
+    raises -- one source's gh error must not suppress the others' alerts.
+    """
+    # Always listed, even on a clean run: a previously-failing covered source
+    # needs its issue closed.
+    try:
+        existing = open_issues_by_key()
+    except (subprocess.CalledProcessError, ValueError) as exc:
+        print(f"could not list existing issues: {exc}", file=sys.stderr)
+        return 1
+
+    # A slug in --failed but not --covered still deserves an alert; covering it
+    # implicitly means we never silently drop a reported failure.
+    targets = list(covered) + [s for s in failed if s not in covered]
+
+    if failed:
+        try:
+            ensure_label()
+        except (subprocess.CalledProcessError, ValueError) as exc:
+            print(f"could not ensure label: {exc}", file=sys.stderr)
+            return 1
+
+    errors = 0
+    for slug in targets:
+        number = existing.get(slug)
+        try:
+            if slug in failed:
+                kind = failed[slug]
+                if number is None:
+                    gh(
+                        "issue", "create",
+                        "--title", issue_title(slug, kind),
+                        "--body", issue_body(slug, kind, run, date, log_tail),
+                        "--label", LABEL,
+                    )
+                    print(f"opened issue for {slug} ({kind})")
+                else:
+                    gh(
+                        "issue", "comment", str(number),
+                        "--body", recurrence_comment(slug, kind, run, date, log_tail),
+                    )
+                    print(f"commented on #{number} for {slug} ({kind})")
+            elif number is not None:
+                gh(
+                    "issue", "comment", str(number),
+                    "--body", recovery_comment(slug, run, date),
+                )
+                gh("issue", "close", str(number))
+                print(f"closed #{number}: {slug} recovered")
+        except (subprocess.CalledProcessError, ValueError) as exc:
+            stderr = getattr(exc, "stderr", "")
+            print(f"failed to report {slug}: {exc} {stderr}", file=sys.stderr)
+            errors += 1
+
+    return 1 if errors else 0
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run", required=True, help="pipeline run label, e.g. pass1")
+    parser.add_argument("--date", required=True, help="run date, YYYY-MM-DD")
+    parser.add_argument(
+        "--covered", required=True,
+        help="comma-separated slugs this run actually examined",
+    )
+    parser.add_argument(
+        "--failed", default="",
+        help="comma-separated slug:kind entries that failed",
+    )
+    parser.add_argument("--log-file", default="", help="log file to excerpt")
+    args = parser.parse_args(argv)
+
+    return report(
+        parse_covered(args.covered),
+        parse_failed(args.failed),
+        args.run,
+        args.date,
+        read_log_tail(args.log_file),
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/report_pipeline_failures.py
+++ b/scripts/report_pipeline_failures.py
@@ -18,9 +18,17 @@ GoComics only, so it covers only GoComics; without that scoping it would
 auto-close a Comics Kingdom issue merely because CK wasn't in its failure
 list -- CK isn't healthy, it simply wasn't examined.
 
-Uses the `gh` CLI, which is installed and authenticated on the pipeline host.
-Never raises into the pipeline: gh errors are logged and reported via exit
-code, and the caller invokes this with `|| true`.
+Runs in GitHub Actions, not on the pipeline host, so issues are authored by
+github-actions[bot]. That is not incidental: GitHub sends no notification for
+an issue you author yourself, so host-side creation (as the repo owner) was
+silently invisible to the person meant to read it. The host dispatches this
+workflow instead. See docs/solutions/best-practices/github-self-authored-issues-dont-notify.md
+
+Detail text is passed in explicitly rather than scraped from the run log: this
+repo is public, and pipeline logs can carry account emails and cookie paths.
+Issues carry structured facts only; the operator reads the real log on the host.
+
+Never raises into the pipeline: gh errors are logged and reported via exit code.
 """
 
 import argparse
@@ -31,7 +39,6 @@ import sys
 LABEL = "pipeline-failure"
 LABEL_COLOR = "b60205"
 MARKER_PREFIX = "Pipeline-Failure-Key: "
-LOG_TAIL_LINES = 40
 
 # Display names for the pipeline's stable slugs. `push` and `preflight` are
 # pseudo-sources: whole-run failures that aren't tied to one comic source.
@@ -78,7 +85,7 @@ def issue_title(slug: str, kind: str) -> str:
     return f"[pipeline] {display_name(slug)} {kind} failed"
 
 
-def issue_body(slug: str, kind: str, run: str, date: str, log_tail: str) -> str:
+def issue_body(slug: str, kind: str, run: str, date: str, detail: str) -> str:
     body = (
         f"The {run} pipeline run on {date} reported a **{kind}** failure for "
         f"**{display_name(slug)}**.\n\n"
@@ -88,18 +95,18 @@ def issue_body(slug: str, kind: str, run: str, date: str, log_tail: str) -> str:
         f"- First seen: {date}\n\n"
         "This issue closes itself automatically when this source next succeeds.\n"
     )
-    if log_tail:
-        body += f"\n<details><summary>Log tail</summary>\n\n```\n{log_tail}\n```\n\n</details>\n"
+    if detail:
+        body += f"\n<details><summary>Log tail</summary>\n\n```\n{detail}\n```\n\n</details>\n"
     body += f"\n{MARKER_PREFIX}{slug}\n"
     return body
 
 
-def recurrence_comment(slug: str, kind: str, run: str, date: str, log_tail: str) -> str:
+def recurrence_comment(slug: str, kind: str, run: str, date: str, detail: str) -> str:
     comment = (
         f"Still failing: **{kind}** on the {run} run of {date}.\n"
     )
-    if log_tail:
-        comment += f"\n<details><summary>Log tail</summary>\n\n```\n{log_tail}\n```\n\n</details>\n"
+    if detail:
+        comment += f"\n<details><summary>Log tail</summary>\n\n```\n{detail}\n```\n\n</details>\n"
     return comment
 
 
@@ -152,19 +159,7 @@ def open_issues_by_key() -> dict:
     return found
 
 
-def read_log_tail(path: str) -> str:
-    if not path:
-        return ""
-    try:
-        with open(path, "r", errors="replace") as handle:
-            lines = handle.read().splitlines()
-    except OSError as exc:
-        print(f"could not read log file {path}: {exc}", file=sys.stderr)
-        return ""
-    return "\n".join(lines[-LOG_TAIL_LINES:])
-
-
-def report(covered, failed, run, date, log_tail="") -> int:
+def report(covered, failed, run, date, detail="") -> int:
     """Reconcile GitHub issues against this run's outcome.
 
     Returns 0 if every source was reported successfully, 1 otherwise. Never
@@ -199,14 +194,14 @@ def report(covered, failed, run, date, log_tail="") -> int:
                     gh(
                         "issue", "create",
                         "--title", issue_title(slug, kind),
-                        "--body", issue_body(slug, kind, run, date, log_tail),
+                        "--body", issue_body(slug, kind, run, date, detail),
                         "--label", LABEL,
                     )
                     print(f"opened issue for {slug} ({kind})")
                 else:
                     gh(
                         "issue", "comment", str(number),
-                        "--body", recurrence_comment(slug, kind, run, date, log_tail),
+                        "--body", recurrence_comment(slug, kind, run, date, detail),
                     )
                     print(f"commented on #{number} for {slug} ({kind})")
             elif number is not None:
@@ -236,7 +231,10 @@ def main(argv=None) -> int:
         "--failed", default="",
         help="comma-separated slug:kind entries that failed",
     )
-    parser.add_argument("--log-file", default="", help="log file to excerpt")
+    parser.add_argument(
+        "--detail", default="",
+        help="extra context for the issue body; must not contain secrets",
+    )
     args = parser.parse_args(argv)
 
     return report(
@@ -244,7 +242,7 @@ def main(argv=None) -> int:
         parse_failed(args.failed),
         args.run,
         args.date,
-        read_log_tail(args.log_file),
+        args.detail,
     )
 
 

--- a/tests/test_report_pipeline_failures.py
+++ b/tests/test_report_pipeline_failures.py
@@ -320,27 +320,36 @@ class TestMain:
         ]) == 0
         assert calls_of(gh_mock, 'issue', 'create') == []
 
-    def test_reads_log_tail_when_given(self, gh_mock, tmp_path):
-        log = tmp_path / 'master_update.log'
-        log.write_text('\n'.join(f'line {i}' for i in range(200)))
-
+    def test_passes_detail_through_to_the_body(self, gh_mock):
         main([
             '--run', 'pass1', '--date', '2026-07-27',
             '--covered', 'gocomics', '--failed', 'gocomics:scrape',
-            '--log-file', str(log),
+            '--detail', 'last commit was 30h ago',
         ])
 
         body = calls_of(gh_mock, 'issue', 'create')[0]
         body = body[body.index('--body') + 1]
-        assert 'line 199' in body
-        assert 'line 0' not in body
+        assert 'last commit was 30h ago' in body
 
-    def test_missing_log_file_is_not_fatal(self, gh_mock, tmp_path):
+    def test_detail_is_optional(self, gh_mock):
         assert main([
             '--run', 'pass1', '--date', '2026-07-27',
             '--covered', 'gocomics', '--failed', 'gocomics:scrape',
-            '--log-file', str(tmp_path / 'nope.log'),
         ]) == 0
+
+    def test_body_contains_no_log_excerpt_by_default(self, gh_mock):
+        """This repo is public; run logs can carry emails and cookie paths.
+
+        Issues carry structured facts only -- the operator reads the real log
+        on the host.
+        """
+        main([
+            '--run', 'pass1', '--date', '2026-07-27',
+            '--covered', 'gocomics', '--failed', 'gocomics:scrape',
+        ])
+        body = calls_of(gh_mock, 'issue', 'create')[0]
+        body = body[body.index('--body') + 1]
+        assert '<details>' not in body
 
 
 class TestSourceNames:

--- a/tests/test_report_pipeline_failures.py
+++ b/tests/test_report_pipeline_failures.py
@@ -1,0 +1,355 @@
+"""Tests for report_pipeline_failures.py.
+
+The `gh` CLI is mocked throughout -- these tests never touch the network and
+never create a real issue.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from scripts.report_pipeline_failures import (
+    LABEL,
+    MARKER_PREFIX,
+    SOURCE_NAMES,
+    issue_body,
+    issue_title,
+    main,
+    open_issues_by_key,
+    parse_failed,
+    report,
+)
+
+
+ALL_COVERED = [
+    'gocomics', 'comicskingdom', 'tinyview', 'newyorker',
+    'farside', 'creators', 'mrboffo', 'push',
+]
+
+
+def gh_responder(open_issues=None, labels=None):
+    """Build a fake `gh` that answers list queries and records mutations.
+
+    `open_issues` maps a marker key -> issue number.
+    """
+    open_issues = open_issues or {}
+    labels = labels if labels is not None else [LABEL]
+
+    def fake_gh(*args):
+        if args[:2] == ('label', 'list'):
+            return json.dumps([{'name': n} for n in labels])
+        if args[:2] == ('issue', 'list'):
+            return json.dumps([
+                {'number': num, 'body': f'blah\n{MARKER_PREFIX}{key}\nblah'}
+                for key, num in open_issues.items()
+            ])
+        return ''
+
+    return fake_gh
+
+
+@pytest.fixture
+def gh_mock():
+    with patch('scripts.report_pipeline_failures.gh') as m:
+        m.side_effect = gh_responder()
+        yield m
+
+
+def calls_of(gh_mock, *prefix):
+    """All recorded gh calls whose leading args match `prefix`."""
+    return [c.args for c in gh_mock.call_args_list if c.args[:len(prefix)] == prefix]
+
+
+class TestParseFailed:
+    def test_parses_source_and_kind(self):
+        assert parse_failed('tinyview:scrape,push:push') == {
+            'tinyview': 'scrape',
+            'push': 'push',
+        }
+
+    def test_empty_string_is_no_failures(self):
+        assert parse_failed('') == {}
+        assert parse_failed('   ') == {}
+
+    def test_tolerates_whitespace_and_blank_entries(self):
+        assert parse_failed(' gocomics:scrape , ,creators:invariant ') == {
+            'gocomics': 'scrape',
+            'creators': 'invariant',
+        }
+
+    def test_slug_without_kind_defaults_to_unknown(self):
+        assert parse_failed('mrboffo') == {'mrboffo': 'unknown'}
+
+
+class TestOpenIssuesByKey:
+    def test_maps_marker_key_to_issue_number(self, gh_mock):
+        gh_mock.side_effect = gh_responder(open_issues={'tinyview': 42, 'push': 7})
+        assert open_issues_by_key() == {'tinyview': 42, 'push': 7}
+
+    def test_ignores_issues_without_a_marker(self, gh_mock):
+        gh_mock.side_effect = lambda *a: json.dumps(
+            [{'number': 1, 'body': 'no marker here'}]
+        ) if a[:2] == ('issue', 'list') else ''
+        assert open_issues_by_key() == {}
+
+    def test_handles_null_body(self, gh_mock):
+        gh_mock.side_effect = lambda *a: json.dumps(
+            [{'number': 1, 'body': None}]
+        ) if a[:2] == ('issue', 'list') else ''
+        assert open_issues_by_key() == {}
+
+    def test_queries_open_issues(self, gh_mock):
+        gh_mock.side_effect = gh_responder()
+        open_issues_by_key()
+        args = calls_of(gh_mock, 'issue', 'list')[0]
+        assert '--state' in args and args[args.index('--state') + 1] == 'open'
+
+    def test_does_not_filter_by_label(self, gh_mock):
+        """Label-filtered listing is eventually consistent on GitHub's side.
+
+        Right after an issue is created it can be missing from a label-filtered
+        list for ~a minute, which made the next run open a duplicate instead of
+        commenting. The body marker is authoritative; the label is cosmetic.
+        """
+        gh_mock.side_effect = gh_responder()
+        open_issues_by_key()
+        assert '--label' not in calls_of(gh_mock, 'issue', 'list')[0]
+
+    def test_duplicate_markers_resolve_to_the_oldest_issue(self, gh_mock):
+        gh_mock.side_effect = lambda *a: json.dumps([
+            {'number': 172, 'body': f'{MARKER_PREFIX}tinyview'},
+            {'number': 171, 'body': f'{MARKER_PREFIX}tinyview'},
+        ]) if a[:2] == ('issue', 'list') else ''
+        assert open_issues_by_key() == {'tinyview': 171}
+
+
+class TestOpensIssueOnFailure:
+    def test_creates_issue_when_none_open(self, gh_mock):
+        report(ALL_COVERED, {'tinyview': 'scrape'}, run='pass1', date='2026-07-27')
+
+        created = calls_of(gh_mock, 'issue', 'create')
+        assert len(created) == 1
+        args = created[0]
+        body = args[args.index('--body') + 1]
+        assert f'{MARKER_PREFIX}tinyview' in body
+        assert args[args.index('--label') + 1] == LABEL
+
+    def test_title_names_the_source_and_kind(self):
+        assert issue_title('tinyview', 'scrape') == '[pipeline] TinyView scrape failed'
+
+    def test_body_records_run_date_and_kind(self):
+        body = issue_body('creators', 'invariant', 'pass1', '2026-07-27', 'tail')
+        assert f'{MARKER_PREFIX}creators' in body
+        assert '2026-07-27' in body
+        assert 'pass1' in body
+        assert 'invariant' in body
+        assert 'tail' in body
+
+    def test_one_issue_per_failing_source(self, gh_mock):
+        report(
+            ALL_COVERED,
+            {'tinyview': 'scrape', 'creators': 'scrape', 'push': 'push'},
+            run='pass1', date='2026-07-27',
+        )
+        assert len(calls_of(gh_mock, 'issue', 'create')) == 3
+
+    def test_does_not_close_anything_when_opening(self, gh_mock):
+        report(ALL_COVERED, {'tinyview': 'scrape'}, run='pass1', date='2026-07-27')
+        assert calls_of(gh_mock, 'issue', 'close') == []
+
+
+class TestCommentsOnRecurrence:
+    def test_comments_instead_of_opening_duplicate(self, gh_mock):
+        gh_mock.side_effect = gh_responder(open_issues={'tinyview': 42})
+
+        report(ALL_COVERED, {'tinyview': 'scrape'}, run='pass1', date='2026-07-28')
+
+        assert calls_of(gh_mock, 'issue', 'create') == []
+        commented = calls_of(gh_mock, 'issue', 'comment')
+        assert len(commented) == 1
+        assert commented[0][2] == '42'
+        assert '2026-07-28' in commented[0][commented[0].index('--body') + 1]
+
+    def test_does_not_close_a_still_failing_source(self, gh_mock):
+        gh_mock.side_effect = gh_responder(open_issues={'tinyview': 42})
+        report(ALL_COVERED, {'tinyview': 'scrape'}, run='pass1', date='2026-07-28')
+        assert calls_of(gh_mock, 'issue', 'close') == []
+
+
+class TestAutoCloseOnRecovery:
+    def test_comments_and_closes_when_source_recovers(self, gh_mock):
+        gh_mock.side_effect = gh_responder(open_issues={'tinyview': 42})
+
+        report(ALL_COVERED, {}, run='pass1', date='2026-07-29')
+
+        closed = calls_of(gh_mock, 'issue', 'close')
+        assert len(closed) == 1
+        assert closed[0][2] == '42'
+        commented = calls_of(gh_mock, 'issue', 'comment')
+        assert len(commented) == 1
+        assert commented[0][2] == '42'
+
+    def test_no_action_for_healthy_source_without_issue(self, gh_mock):
+        report(ALL_COVERED, {}, run='pass1', date='2026-07-29')
+        assert calls_of(gh_mock, 'issue', 'create') == []
+        assert calls_of(gh_mock, 'issue', 'close') == []
+        assert calls_of(gh_mock, 'issue', 'comment') == []
+
+    def test_closes_only_the_recovered_source(self, gh_mock):
+        gh_mock.side_effect = gh_responder(open_issues={'tinyview': 42, 'creators': 43})
+
+        report(ALL_COVERED, {'creators': 'scrape'}, run='pass1', date='2026-07-29')
+
+        closed = calls_of(gh_mock, 'issue', 'close')
+        assert len(closed) == 1
+        assert closed[0][2] == '42'
+
+
+class TestCoveredScoping:
+    """Pass 2 only examines GoComics -- it must never touch other sources."""
+
+    def test_does_not_close_issues_for_uncovered_sources(self, gh_mock):
+        gh_mock.side_effect = gh_responder(
+            open_issues={'comicskingdom': 99, 'tinyview': 98}
+        )
+
+        report(['gocomics', 'push'], {}, run='pass2', date='2026-07-27')
+
+        assert calls_of(gh_mock, 'issue', 'close') == []
+        assert calls_of(gh_mock, 'issue', 'comment') == []
+
+    def test_pass2_still_closes_its_own_source(self, gh_mock):
+        gh_mock.side_effect = gh_responder(open_issues={'gocomics': 50})
+
+        report(['gocomics', 'push'], {}, run='pass2', date='2026-07-27')
+
+        closed = calls_of(gh_mock, 'issue', 'close')
+        assert len(closed) == 1
+        assert closed[0][2] == '50'
+
+    def test_failure_for_uncovered_source_is_still_reported(self, gh_mock):
+        """A slug in --failed but not --covered should not be silently dropped."""
+        report(['gocomics'], {'tinyview': 'scrape'}, run='pass1', date='2026-07-27')
+
+        created = calls_of(gh_mock, 'issue', 'create')
+        assert len(created) == 1
+        assert f'{MARKER_PREFIX}tinyview' in created[0][created[0].index('--body') + 1]
+
+
+class TestLabelHandling:
+    def test_creates_label_when_absent(self, gh_mock):
+        gh_mock.side_effect = gh_responder(labels=['bug'])
+        report(ALL_COVERED, {'tinyview': 'scrape'}, run='pass1', date='2026-07-27')
+        assert len(calls_of(gh_mock, 'label', 'create')) == 1
+
+    def test_does_not_recreate_existing_label(self, gh_mock):
+        gh_mock.side_effect = gh_responder(labels=[LABEL])
+        report(ALL_COVERED, {'tinyview': 'scrape'}, run='pass1', date='2026-07-27')
+        assert calls_of(gh_mock, 'label', 'create') == []
+
+    def test_skips_label_work_when_nothing_failed(self, gh_mock):
+        report(ALL_COVERED, {}, run='pass1', date='2026-07-27')
+        assert calls_of(gh_mock, 'label', 'list') == []
+
+
+class TestResilience:
+    def test_gh_error_on_one_source_does_not_abort_others(self, gh_mock):
+        base = gh_responder()
+        seen = {'n': 0}
+
+        def flaky(*args):
+            if args[:2] == ('issue', 'create'):
+                seen['n'] += 1
+                if seen['n'] == 1:
+                    raise subprocess.CalledProcessError(1, 'gh', stderr='boom')
+            return base(*args)
+
+        gh_mock.side_effect = flaky
+
+        rc = report(
+            ALL_COVERED,
+            {'tinyview': 'scrape', 'creators': 'scrape'},
+            run='pass1', date='2026-07-27',
+        )
+
+        assert len(calls_of(gh_mock, 'issue', 'create')) == 2
+        assert rc != 0
+
+    def test_returns_zero_when_all_reporting_succeeds(self, gh_mock):
+        assert report(
+            ALL_COVERED, {'tinyview': 'scrape'}, run='pass1', date='2026-07-27'
+        ) == 0
+
+    def test_listing_failure_does_not_raise(self, gh_mock):
+        def broken(*args):
+            if args[:2] == ('issue', 'list'):
+                raise subprocess.CalledProcessError(1, 'gh', stderr='rate limited')
+            return gh_responder()(*args)
+
+        gh_mock.side_effect = broken
+        assert report(
+            ALL_COVERED, {'tinyview': 'scrape'}, run='pass1', date='2026-07-27'
+        ) != 0
+
+
+class TestMain:
+    def test_wires_arguments_through(self, gh_mock):
+        rc = main([
+            '--run', 'pass2',
+            '--date', '2026-07-27',
+            '--covered', 'gocomics,push',
+            '--failed', 'gocomics:scrape',
+        ])
+
+        assert rc == 0
+        created = calls_of(gh_mock, 'issue', 'create')
+        assert len(created) == 1
+        body = created[0][created[0].index('--body') + 1]
+        assert f'{MARKER_PREFIX}gocomics' in body
+        assert 'pass2' in body
+
+    def test_failed_flag_is_optional(self, gh_mock):
+        assert main([
+            '--run', 'pass1', '--date', '2026-07-27', '--covered', 'gocomics',
+        ]) == 0
+        assert calls_of(gh_mock, 'issue', 'create') == []
+
+    def test_reads_log_tail_when_given(self, gh_mock, tmp_path):
+        log = tmp_path / 'master_update.log'
+        log.write_text('\n'.join(f'line {i}' for i in range(200)))
+
+        main([
+            '--run', 'pass1', '--date', '2026-07-27',
+            '--covered', 'gocomics', '--failed', 'gocomics:scrape',
+            '--log-file', str(log),
+        ])
+
+        body = calls_of(gh_mock, 'issue', 'create')[0]
+        body = body[body.index('--body') + 1]
+        assert 'line 199' in body
+        assert 'line 0' not in body
+
+    def test_missing_log_file_is_not_fatal(self, gh_mock, tmp_path):
+        assert main([
+            '--run', 'pass1', '--date', '2026-07-27',
+            '--covered', 'gocomics', '--failed', 'gocomics:scrape',
+            '--log-file', str(tmp_path / 'nope.log'),
+        ]) == 0
+
+
+class TestSourceNames:
+    def test_every_pipeline_slug_has_a_display_name(self):
+        expected = {
+            'gocomics', 'comicskingdom', 'tinyview', 'newyorker',
+            'farside', 'creators', 'mrboffo', 'push', 'preflight',
+        }
+        assert expected <= set(SOURCE_NAMES)
+
+    def test_unknown_slug_falls_back_to_the_slug(self):
+        assert 'mystery' in issue_title('mystery', 'scrape')


### PR DESCRIPTION
## Why

The twice-daily pipeline runs unattended (03:05 and 13:00). Its only failure signal today is a macOS desktop notification on the Mac Mini — invisible when nobody's sitting there. A source can break and stay broken until someone happens to read `logs/master_update.log`.

This turns a failure into a durable, remote alert.

## What

One GitHub issue per failing source, identified by a `Pipeline-Failure-Key: <slug>` marker in the body:

| state | action |
|---|---|
| failing, no open issue | open one |
| failing, open issue exists | comment on it |
| healthy, open issue exists | comment + close (recovered) |
| healthy, no open issue | nothing |

**Scope:** scrape + invariant + push failures, plus the SSH preflight. Feed-generation and `git fetch` failures stay log-only by design.

## Design notes

**The preflight case matters most.** Both scripts abort with `exit 0` when SSH auth fails — *before any scraping*. An end-of-run-only report would produce zero issues on the run that failed hardest. That's exactly the failure mode of #168, so the abort branches report too.

**`--covered` is safety-critical.** Pass 2 scrapes GoComics only, so it passes `--covered gocomics,push,preflight`. Without that scoping, the 13:00 run would auto-close an open Comics Kingdom issue merely because CK wasn't in its failure list — CK isn't healthy there, it simply wasn't examined.

**Host-side, not CI.** If the failure is the `git push` itself, a failure manifest never reaches GitHub — the alerts you most need are the ones that approach drops. `gh` is already installed and authenticated on the Mini, and I verified its keychain token works under launchd (throwaway LaunchAgent, since that was the one real unknown), so no new secret was needed.

**Python, not bash.** The host is bash 3.2 (no associative arrays). Logic lives in `scripts/report_pipeline_failures.py`, unit-tested with `gh` mocked. Bash only collects `FAILED_KEYS` slugs and shells out with `|| true`, so a gh outage can never break a run.

## Testing

- 35 new unit tests, `gh` fully mocked — no network, no real issues. Full suite: **376 passed**.
- Verified end-to-end against the real repo: open → comment (no duplicate) → close → no-op. Test issues deleted afterward.
- That E2E run caught a bug the mocks could not: `gh issue list --label X` is **eventually consistent** and returned `[]` for ~a minute after creating an issue, so a second run opened a duplicate. Fixed by matching on the body marker via an unfiltered query — the label is now purely for human filtering. Written up in `docs/solutions/logic-errors/github-issue-list-label-eventual-consistency.md`.

## Known tradeoff

No consecutive-failure threshold, per design discussion. Known-flaky sources (TinyView lapses, Comics Kingdom sessions expiring ~every 10 days) will open an issue on first failure, and a long outage accrues one comment per run. That comment trail is the outage-duration record you'd otherwise reconstruct from logs. Easy to add a threshold later if it proves noisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MRMLtUKyM8XfrbGQqNT4t