### PR TITLE
feat: dead-man's switch for a silent pipeline

### DIFF
--- a/.github/workflows/pipeline-heartbeat.yml
+++ b/.github/workflows/pipeline-heartbeat.yml
@@ -1,0 +1,49 @@
+name: Pipeline Heartbeat
+
+# Dead-man's switch for the daily feed pipeline.
+#
+# report_pipeline_failures.py reports what broke *during* a run. It cannot
+# report a run that never happened: if the Mac Mini is off, asleep, or
+# network-dead, no step fails, so nothing is reported and a dead pipeline looks
+# exactly like a healthy one.
+#
+# This runs on GitHub's infrastructure precisely because the thing it monitors
+# is the Mini -- a heartbeat hosted on the machine it watches dies with it.
+#
+# 11:00 UTC is ~06:00 America/Chicago: about three hours after the 03:05 Pass 1
+# run, so a missed night surfaces before the morning inbox check.
+
+on:
+  schedule:
+    - cron: '0 11 * * *'
+  workflow_dispatch:
+    inputs:
+      stale_hours:
+        description: 'Hours without a pipeline commit before alerting'
+        required: false
+        default: '20'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  heartbeat:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Need history deep enough to find recent pipeline commits; the
+          # default fetch-depth of 1 would make every run look stale.
+          fetch-depth: 200
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Check pipeline heartbeat
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STALE_HOURS: ${{ inputs.stale_hours || '20' }}
+        run: python scripts/check_pipeline_heartbeat.py --stale-hours "$STALE_HOURS"

--- a/scripts/check_pipeline_heartbeat.py
+++ b/scripts/check_pipeline_heartbeat.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Alert when the daily pipeline goes silent.
+
+`report_pipeline_failures.py` reports what broke *during* a run. It structurally
+cannot report a run that never happened: if the Mac Mini is off, asleep, or
+network-dead, no step fails, so no issue is opened and a dead pipeline looks
+exactly like a healthy one.
+
+This is the dead-man's switch for that case. It deliberately runs on GitHub
+Actions rather than on the Mini -- a heartbeat hosted on the machine it is
+monitoring dies with it.
+
+Health signal: the pipeline commits feed updates to main on every successful
+run (twice daily). If no *pipeline* commit has landed within --stale-hours, the
+pipeline is presumed down. Human commits are ignored on purpose: a code push at
+midnight must not mask a pipeline that stopped running.
+
+Reuses the reporter's issue machinery, so a heartbeat alert opens, comments,
+and auto-closes exactly like a source failure -- and clears itself as soon as
+the pipeline commits again.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+import time
+from datetime import date
+
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+
+from report_pipeline_failures import report  # noqa: E402
+
+HEARTBEAT_SLUG = "heartbeat"
+
+# Pass 1 runs at 03:05 and Pass 2 at 13:00, so a healthy repo sees a pipeline
+# commit every day. 20h tolerates a normal daily cadence plus schedule drift
+# while still catching a wholly missed night.
+DEFAULT_STALE_HOURS = 20
+
+# Commit subjects the pipeline itself writes (see local_master_update.sh and
+# local_pass2_update.sh). Matched as prefixes.
+PIPELINE_COMMIT_PATTERNS = (
+    "Update all comic feeds for",
+    "Update comic feeds for",
+    "Pass 2 GoComics feed update for",
+)
+
+LOG_DEPTH = 200
+
+
+def now_ts() -> int:
+    return int(time.time())
+
+
+def git_log() -> str:
+    return subprocess.run(
+        ["git", "log", f"-n{LOG_DEPTH}", "--format=%ct%x09%s"],
+        check=True, capture_output=True, text=True,
+    ).stdout
+
+
+def find_latest_pipeline_commit(log_output: str):
+    """Return (timestamp, subject) of the newest pipeline commit, or None.
+
+    `git log` is newest-first, so the first match wins.
+    """
+    for line in (log_output or "").splitlines():
+        timestamp, _, subject = line.partition("\t")
+        if not subject:
+            continue
+        if not any(subject.startswith(p) for p in PIPELINE_COMMIT_PATTERNS):
+            continue
+        if not re.fullmatch(r"\d+", timestamp.strip()):
+            continue
+        return int(timestamp), subject
+    return None
+
+
+def staleness(log_output: str, now: int, stale_hours: float):
+    """Return (is_stale, age_in_hours_or_None, human detail)."""
+    latest = find_latest_pipeline_commit(log_output)
+    if latest is None:
+        return True, None, (
+            f"Found no pipeline commit in the last {LOG_DEPTH} commits on main."
+        )
+
+    timestamp, subject = latest
+    age_hours = (now - timestamp) / 3600.0
+    detail = (
+        f"Last pipeline commit was {age_hours:.1f}h ago: \"{subject}\"\n"
+        f"Threshold: {stale_hours}h."
+    )
+    return age_hours > stale_hours, age_hours, detail
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--stale-hours", type=float, default=DEFAULT_STALE_HOURS,
+        help="hours without a pipeline commit before alerting",
+    )
+    args = parser.parse_args(argv)
+
+    stale, age_hours, detail = staleness(git_log(), now_ts(), args.stale_hours)
+
+    if stale:
+        print(f"STALE: {detail}")
+        detail = (
+            f"{detail}\n\n"
+            "No pipeline commit has landed in the expected window, which means "
+            "the daily run did not happen at all -- not that a source failed. "
+            "Check that the Mac Mini is awake and online and that the LaunchAgents "
+            "(com.comiccaster.master / com.comiccaster.pass2) are loaded."
+        )
+        failed = {HEARTBEAT_SLUG: "heartbeat"}
+    else:
+        print(f"OK: {detail}")
+        failed = {}
+
+    # Covers only the heartbeat: this check examined no comic sources, so it
+    # must never auto-close a source issue.
+    return report(
+        [HEARTBEAT_SLUG],
+        failed,
+        "heartbeat",
+        date.today().isoformat(),
+        detail,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/report_pipeline_failures.py
+++ b/scripts/report_pipeline_failures.py
@@ -52,6 +52,7 @@ SOURCE_NAMES = {
     "mrboffo": "Mr. Boffo",
     "push": "Git push",
     "preflight": "SSH preflight",
+    "heartbeat": "Daily pipeline",
 }
 
 
@@ -96,7 +97,7 @@ def issue_body(slug: str, kind: str, run: str, date: str, detail: str) -> str:
         "This issue closes itself automatically when this source next succeeds.\n"
     )
     if detail:
-        body += f"\n<details><summary>Log tail</summary>\n\n```\n{detail}\n```\n\n</details>\n"
+        body += f"\n<details><summary>Details</summary>\n\n```\n{detail}\n```\n\n</details>\n"
     body += f"\n{MARKER_PREFIX}{slug}\n"
     return body
 
@@ -106,7 +107,7 @@ def recurrence_comment(slug: str, kind: str, run: str, date: str, detail: str) -
         f"Still failing: **{kind}** on the {run} run of {date}.\n"
     )
     if detail:
-        comment += f"\n<details><summary>Log tail</summary>\n\n```\n{detail}\n```\n\n</details>\n"
+        comment += f"\n<details><summary>Details</summary>\n\n```\n{detail}\n```\n\n</details>\n"
     return comment
 
 

--- a/tests/test_check_pipeline_heartbeat.py
+++ b/tests/test_check_pipeline_heartbeat.py
@@ -1,0 +1,173 @@
+"""Tests for check_pipeline_heartbeat.py.
+
+The heartbeat answers a question the failure reporter structurally cannot: did
+the pipeline run at all? A Mini that is off or asleep produces no failing step,
+so silence looks exactly like success. These tests pin that logic down.
+"""
+
+import os
+import sys
+
+import pytest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from scripts.check_pipeline_heartbeat import (
+    DEFAULT_STALE_HOURS,
+    HEARTBEAT_SLUG,
+    find_latest_pipeline_commit,
+    main,
+    staleness,
+)
+
+
+# 2026-07-27 12:00:00 UTC, an arbitrary fixed "now" for age arithmetic.
+NOW = 1785196800
+HOUR = 3600
+
+
+def log(*entries):
+    """Build `git log --format=%ct%x09%s` output."""
+    return "\n".join(f"{ts}\t{subject}" for ts, subject in entries)
+
+
+class TestFindLatestPipelineCommit:
+    def test_finds_a_pass1_feed_commit(self):
+        out = log((NOW - 3 * HOUR, "Update all comic feeds for 2026-07-27"))
+        assert find_latest_pipeline_commit(out) == (
+            NOW - 3 * HOUR, "Update all comic feeds for 2026-07-27"
+        )
+
+    def test_finds_a_pass2_commit(self):
+        out = log((NOW - HOUR, "Pass 2 GoComics feed update for 2026-07-27"))
+        assert find_latest_pipeline_commit(out)[0] == NOW - HOUR
+
+    def test_finds_a_recovery_commit(self):
+        out = log((NOW - HOUR, "Update comic feeds for 2026-07-27 (recovery after push conflict)"))
+        assert find_latest_pipeline_commit(out)[0] == NOW - HOUR
+
+    def test_ignores_non_pipeline_commits(self):
+        """A human code commit must not mask a dead pipeline."""
+        out = log(
+            (NOW - HOUR, "feat: add a new comic source"),
+            (NOW - 30 * HOUR, "Update all comic feeds for 2026-07-26"),
+        )
+        assert find_latest_pipeline_commit(out)[0] == NOW - 30 * HOUR
+
+    def test_returns_newest_when_several_match(self):
+        out = log(
+            (NOW - 2 * HOUR, "Update all comic feeds for 2026-07-27"),
+            (NOW - 26 * HOUR, "Update all comic feeds for 2026-07-26"),
+        )
+        assert find_latest_pipeline_commit(out)[0] == NOW - 2 * HOUR
+
+    def test_returns_none_when_no_pipeline_commits(self):
+        out = log((NOW - HOUR, "docs: update the readme"))
+        assert find_latest_pipeline_commit(out) is None
+
+    def test_handles_empty_log(self):
+        assert find_latest_pipeline_commit("") is None
+
+    def test_ignores_malformed_lines(self):
+        out = "garbage\nnot-a-timestamp\tUpdate all comic feeds for 2026-07-27"
+        assert find_latest_pipeline_commit(out) is None
+
+
+class TestStaleness:
+    def test_fresh_run_is_healthy(self):
+        out = log((NOW - 3 * HOUR, "Update all comic feeds for 2026-07-27"))
+        stale, age, _ = staleness(out, NOW, DEFAULT_STALE_HOURS)
+        assert stale is False
+        assert age == pytest.approx(3.0)
+
+    def test_old_run_is_stale(self):
+        out = log((NOW - 30 * HOUR, "Update all comic feeds for 2026-07-26"))
+        stale, age, _ = staleness(out, NOW, DEFAULT_STALE_HOURS)
+        assert stale is True
+        assert age == pytest.approx(30.0)
+
+    def test_no_pipeline_commit_at_all_is_stale(self):
+        stale, age, detail = staleness("", NOW, DEFAULT_STALE_HOURS)
+        assert stale is True
+        assert age is None
+        assert 'no' in detail.lower()
+
+    def test_threshold_is_configurable(self):
+        out = log((NOW - 10 * HOUR, "Update all comic feeds for 2026-07-27"))
+        assert staleness(out, NOW, 8)[0] is True
+        assert staleness(out, NOW, 12)[0] is False
+
+    def test_boundary_is_not_stale_at_exactly_the_threshold(self):
+        out = log((NOW - 20 * HOUR, "Update all comic feeds for 2026-07-26"))
+        assert staleness(out, NOW, 20)[0] is False
+
+    def test_default_threshold_tolerates_a_normal_daily_cadence(self):
+        """Pass 1 runs daily; a ~24h-old commit checked hours later is normal."""
+        assert DEFAULT_STALE_HOURS >= 20
+
+    def test_detail_mentions_the_age_and_subject(self):
+        out = log((NOW - 30 * HOUR, "Update all comic feeds for 2026-07-26"))
+        detail = staleness(out, NOW, DEFAULT_STALE_HOURS)[2]
+        assert '30' in detail
+        assert '2026-07-26' in detail
+
+
+class TestMain:
+    @patch('scripts.check_pipeline_heartbeat.report')
+    @patch('scripts.check_pipeline_heartbeat.git_log')
+    def test_reports_failure_when_stale(self, mock_log, mock_report):
+        mock_log.return_value = log((NOW - 40 * HOUR, "Update all comic feeds for 2026-07-25"))
+        mock_report.return_value = 0
+
+        with patch('scripts.check_pipeline_heartbeat.now_ts', return_value=NOW):
+            assert main([]) == 0
+
+        covered, failed = mock_report.call_args.args[0], mock_report.call_args.args[1]
+        assert covered == [HEARTBEAT_SLUG]
+        assert HEARTBEAT_SLUG in failed
+
+    @patch('scripts.check_pipeline_heartbeat.report')
+    @patch('scripts.check_pipeline_heartbeat.git_log')
+    def test_reports_healthy_when_fresh(self, mock_log, mock_report):
+        mock_log.return_value = log((NOW - 2 * HOUR, "Update all comic feeds for 2026-07-27"))
+        mock_report.return_value = 0
+
+        with patch('scripts.check_pipeline_heartbeat.now_ts', return_value=NOW):
+            assert main([]) == 0
+
+        # Healthy: covered so a prior heartbeat issue auto-closes, none failed.
+        assert mock_report.call_args.args[0] == [HEARTBEAT_SLUG]
+        assert mock_report.call_args.args[1] == {}
+
+    @patch('scripts.check_pipeline_heartbeat.report')
+    @patch('scripts.check_pipeline_heartbeat.git_log')
+    def test_only_covers_heartbeat(self, mock_log, mock_report):
+        """Must never auto-close a source issue -- it examined no sources."""
+        mock_log.return_value = log((NOW - 2 * HOUR, "Update all comic feeds for 2026-07-27"))
+        mock_report.return_value = 0
+
+        with patch('scripts.check_pipeline_heartbeat.now_ts', return_value=NOW):
+            main([])
+
+        assert mock_report.call_args.args[0] == [HEARTBEAT_SLUG]
+
+    @patch('scripts.check_pipeline_heartbeat.report')
+    @patch('scripts.check_pipeline_heartbeat.git_log')
+    def test_threshold_flag_is_honoured(self, mock_log, mock_report):
+        mock_log.return_value = log((NOW - 10 * HOUR, "Update all comic feeds for 2026-07-27"))
+        mock_report.return_value = 0
+
+        with patch('scripts.check_pipeline_heartbeat.now_ts', return_value=NOW):
+            main(['--stale-hours', '8'])
+
+        assert HEARTBEAT_SLUG in mock_report.call_args.args[1]
+
+    @patch('scripts.check_pipeline_heartbeat.report')
+    @patch('scripts.check_pipeline_heartbeat.git_log')
+    def test_propagates_reporter_exit_code(self, mock_log, mock_report):
+        mock_log.return_value = log((NOW - 2 * HOUR, "Update all comic feeds for 2026-07-27"))
+        mock_report.return_value = 1
+
+        with patch('scripts.check_pipeline_heartbeat.now_ts', return_value=NOW):
+            assert main([]) == 1


### PR DESCRIPTION
**Stacked on #173** — base is `feat/pipeline-failure-github-issues`, so review that one first. The diff here is just the heartbeat.

## Why

#173 reports what breaks *during* a run. It structurally cannot report a run that never happened.

If the Mini is off, asleep, or network-dead, no step fails — so nothing is reported, no issue opens, and a dead pipeline looks exactly like a healthy morning. Silence is indistinguishable from success, which is the one failure mode that defeats "I'll catch it when I check email."

## What

A scheduled GitHub Action that asks: **has a pipeline commit landed on `main` in the last 20 hours?** If not, it opens an issue through the same open/comment/auto-close machinery as #173, so it clears itself the moment the pipeline commits again.

It runs on GitHub Actions, not the Mini, deliberately — a heartbeat hosted on the machine it monitors dies with it.

Runs at 11:00 UTC (~06:00 America/Chicago), about three hours after the 03:05 Pass 1, so a missed night surfaces before the morning inbox check.

## Design notes

**Human commits are ignored when measuring staleness.** Only subjects the pipeline itself writes count (`Update all comic feeds for`, `Pass 2 GoComics feed update for`, and the recovery variant). Otherwise a code push at midnight would reset the clock and mask a pipeline that had stopped running.

**`fetch-depth: 200`** on checkout — the default depth of 1 would make every run look stale.

**Covers only `heartbeat`.** This check examines no comic sources, so it can never auto-close a source issue.

**20h threshold** tolerates the normal daily cadence plus schedule drift while still catching a wholly missed night.

## Testing

20 new unit tests (time and `git log` injected, no clock or network dependency): commit-subject matching, human-commit exclusion, staleness boundaries, no-pipeline-commit-at-all, threshold config, and the covered-scoping guard. Full suite: **397 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MRMLtUKyM8XfrbGQqNT4t