### PR TITLE
feat: make the Comics Kingdom session expiry visible

### DIFF
--- a/docs/LOCAL_AUTOMATION_README.md
+++ b/docs/LOCAL_AUTOMATION_README.md
@@ -63,6 +63,7 @@ An earlier hybrid design split scraping between a laptop (one source) and GitHub
 | `scripts/generate_*.py` | Phase 2 generators; each reads `data/*.json` and writes to `public/feeds/*.xml` |
 | `scripts/report_pipeline_failures.py` | Opens / comments / closes the GitHub issue for each failing source. Runs in Actions, not on the host (see Failure alerting) |
 | `scripts/check_pipeline_heartbeat.py` | Dead-man's switch — alerts when no pipeline commit has landed in 20h |
+| `scripts/check_ck_session.py` | Reads the CK token expiry; used by the reauth script and the daily expiry alert |
 | `.github/workflows/pipeline-alert.yml` | Dispatched by both passes; runs the reporter under `GITHUB_TOKEN` |
 | `.github/workflows/pipeline-heartbeat.yml` | Scheduled 11:00 UTC; runs the heartbeat check |
 | `scripts/reauth_comicskingdom.py` | Manual Comics Kingdom session refresh |
@@ -88,7 +89,20 @@ These are the load-bearing assumptions the pipeline relies on. Detailed provisio
 
 - `GOCOMICS_EMAIL`, `GOCOMICS_PASSWORD`
 
-Comics Kingdom does not use env vars. Session state lives in a Chrome profile at `~/.comicskingdom_chrome_profile/`, seeded by `python scripts/reauth_comicskingdom.py`. Sessions last about a week; refresh when the daily run reports `profile has no stored session`, or proactively on a weekly cadence.
+Comics Kingdom does not use env vars. Session state lives in a Chrome profile at `~/.comicskingdom_chrome_profile/`, seeded by `python scripts/reauth_comicskingdom.py`.
+
+**CK's token lasts exactly 7 days** — measured from the cookie, not estimated. The operator reauths weekly, so the margin is hours, not days: a reauth that fails to mint a new token means a failed run the next morning (2026-07-28). Two guards:
+
+- `scripts/reauth_comicskingdom.py` reads the expiry before and after login and tells you whether it **actually moved**. Trust that line rather than the browser looking logged in. It exits non-zero if the expiry did not change.
+- The daily run checks the expiry and opens a `[pipeline] Comics Kingdom session needs a reauth` issue when fewer than 2 days remain, so a silent reauth failure surfaces the same day instead of as an outage.
+
+Check it any time:
+
+```bash
+python scripts/check_ck_session.py
+```
+
+Let the reauth script close the browser. Closing the window by hand can leave Chrome's new cookies unflushed — the leading hypothesis for the 2026-07-28 failure.
 
 ## Dev mode (not on the production host)
 
@@ -201,14 +215,20 @@ This is a real production run: it scrapes, commits, and pushes. Use it to valida
 
 ### Comics Kingdom session expired
 
-When the daily run reports `profile has no stored session`, refresh:
+When the daily run reports an auth failure, or a session alert arrives:
 
 ```bash
 source venv/bin/activate
 python scripts/reauth_comicskingdom.py
 ```
 
-A browser will open; complete the login flow. Session state is saved automatically. Next run picks it up.
+A browser opens; complete the login flow and **let the script close it**. The script then reports whether the expiry moved:
+
+```
+✅ Session renewed: expires 2026-08-04 11:21 UTC (7.0 days from now).
+```
+
+If it instead prints `❌ Session expiry did NOT move`, the login did not produce a new token — re-run it. That silent no-op is what caused the 2026-07-28 outage, and it is invisible in the browser.
 
 ### LaunchAgent not firing
 

--- a/scripts/check_ck_session.py
+++ b/scripts/check_ck_session.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Report when the Comics Kingdom session token expires.
+
+CK issues a **7-day** token, and the operator reauths on a 7-day cadence, so
+the safety margin is hours rather than days. A reauth that silently fails to
+mint a new token is therefore an outage the next morning -- which is exactly
+what happened on 2026-07-28.
+
+This makes that invisible clock visible. Run it:
+
+  * right after a reauth, to confirm the expiry actually moved ~7 days out
+    (`reauth_comicskingdom.py` does this automatically);
+  * from the daily pipeline, to alert while there is still time to act.
+
+Reads the expiry straight out of the Chrome profile's cookie store. The store
+is copied before querying, so this is safe to run while Chrome holds the
+profile open and never mutates the operator's session.
+"""
+
+import argparse
+import shutil
+import sqlite3
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+PROFILE_DIR = Path.home() / ".comicskingdom_chrome_profile"
+CK_HOST = "comicskingdom.com"
+TOKEN_NAME = "__Secure-next-auth.session-token"
+
+# The token lasts 7 days and the daily run needs it at 03:06, so warning at 2
+# days leaves two whole mornings to act before anything breaks.
+DEFAULT_WARN_DAYS = 2
+
+# Chrome stores timestamps as microseconds since 1601-01-01 UTC.
+CHROME_EPOCH_OFFSET_SECONDS = 11644473600
+
+
+def chrome_time_to_datetime(expires_utc: int):
+    """Convert a Chrome timestamp to UTC. 0 means a session-only cookie."""
+    if not expires_utc:
+        return None
+    unix_seconds = expires_utc / 1_000_000 - CHROME_EPOCH_OFFSET_SECONDS
+    return datetime.fromtimestamp(unix_seconds, tz=timezone.utc)
+
+
+def datetime_to_chrome_time(when: datetime) -> int:
+    return int((when.timestamp() + CHROME_EPOCH_OFFSET_SECONDS) * 1_000_000)
+
+
+def read_token_expiry(profile_dir):
+    """Return the auth token's expiry, or None if absent/unreadable.
+
+    Copies the cookie DB first: Chrome may hold a lock on it, and we must never
+    write to the operator's live profile.
+    """
+    db_path = Path(profile_dir) / "Default" / "Cookies"
+    if not db_path.exists():
+        return None
+
+    with tempfile.TemporaryDirectory() as tmp:
+        copy = Path(tmp) / "Cookies"
+        try:
+            shutil.copy2(db_path, copy)
+            conn = sqlite3.connect(f"file:{copy}?mode=ro", uri=True)
+            try:
+                row = conn.execute(
+                    "SELECT expires_utc FROM cookies "
+                    "WHERE host_key = ? AND name = ?",
+                    (CK_HOST, TOKEN_NAME),
+                ).fetchone()
+            finally:
+                conn.close()
+        except (OSError, sqlite3.Error) as exc:
+            print(f"could not read cookie store: {exc}", file=sys.stderr)
+            return None
+
+    return chrome_time_to_datetime(row[0]) if row else None
+
+
+def days_remaining(expiry: datetime, now: datetime) -> float:
+    return (expiry - now).total_seconds() / 86400.0
+
+
+def evaluate(expiry, now: datetime, warn_days: float):
+    """Return (status, detail). Status is ok | expiring | expired | missing."""
+    if expiry is None:
+        return "missing", (
+            "No Comics Kingdom session token found in the Chrome profile. "
+            "Run scripts/reauth_comicskingdom.py."
+        )
+
+    remaining = days_remaining(expiry, now)
+    stamp = expiry.strftime("%Y-%m-%d %H:%M UTC")
+
+    if remaining <= 0:
+        return "expired", (
+            f"Comics Kingdom session EXPIRED {abs(remaining):.1f} days ago "
+            f"(expired {stamp}). Run scripts/reauth_comicskingdom.py."
+        )
+    if remaining <= warn_days:
+        return "expiring", (
+            f"Comics Kingdom session expires in {remaining:.1f} days ({stamp}). "
+            "Run scripts/reauth_comicskingdom.py."
+        )
+    return "ok", (
+        f"Comics Kingdom session ok: {remaining:.1f} days remaining ({stamp})."
+    )
+
+
+def describe_renewal(before, after, now: datetime):
+    """Compare token expiry across a reauth. Returns (renewed, message).
+
+    This is the check that catches a reauth which *looked* fine in the browser
+    but left no new token on disk: the login page redirects, the operator sees
+    a logged-in page, and the old expiry is still sitting there unchanged.
+    """
+    if after is None:
+        return False, (
+            "No session token on disk after login. The session did NOT persist. "
+            "Re-run the reauth and let the script close the browser itself "
+            "rather than closing the window by hand."
+        )
+
+    stamp = after.strftime("%Y-%m-%d %H:%M UTC")
+    remaining = days_remaining(after, now)
+
+    if before is not None and after <= before:
+        return False, (
+            f"Session expiry did NOT move (still {stamp}). The login did not "
+            "produce a new token, so it will expire on the old schedule "
+            f"({remaining:.1f} days). Re-run the reauth."
+        )
+
+    return True, (
+        f"Session renewed: expires {stamp} ({remaining:.1f} days from now)."
+    )
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile", default=str(PROFILE_DIR),
+        help="Chrome profile directory to inspect",
+    )
+    parser.add_argument(
+        "--warn-days", type=float, default=DEFAULT_WARN_DAYS,
+        help="warn when fewer than this many days remain",
+    )
+    parser.add_argument("--quiet", action="store_true", help="suppress output")
+    parser.add_argument(
+        "--detail-only", action="store_true",
+        help="print just the one-line detail (for the alert body)",
+    )
+    args = parser.parse_args(argv)
+
+    expiry = read_token_expiry(args.profile)
+    status, detail = evaluate(expiry, datetime.now(timezone.utc), args.warn_days)
+
+    if args.detail_only:
+        print(detail)
+    elif not args.quiet:
+        icon = {"ok": "✅", "expiring": "⚠️", "expired": "❌", "missing": "❌"}[status]
+        print(f"{icon} {detail}")
+
+    return 0 if status == "ok" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/local_master_update.sh
+++ b/scripts/local_master_update.sh
@@ -35,7 +35,7 @@ FAILED_KEYS=()
 # Pass 1 covers everything; Pass 2 covers GoComics only.
 # `preflight` is included because reaching the end of a run proves it passed,
 # which is what auto-closes a preflight issue from a previous run.
-ALERT_COVERED="gocomics,comicskingdom,tinyview,newyorker,farside,creators,mrboffo,push,preflight"
+ALERT_COVERED="gocomics,comicskingdom,tinyview,newyorker,farside,creators,mrboffo,push,preflight,cksession"
 
 # Load environment variables (.env has GoComics credentials)
 if [ -f "$REPO_DIR/.env" ]; then
@@ -290,6 +290,20 @@ check_scrape_output "Far Side"       "farside"       "data/farside_daily_$DATE_S
 check_scrape_output "Far Side"       "farside"       "data/farside_new_$DATE_STR.json"
 check_scrape_output "Creators"       "creators"      "data/creators_$DATE_STR.json"
 check_scrape_output "Mr. Boffo"      "mrboffo"       "data/mrboffo_$DATE_STR.json"
+
+# Comics Kingdom session expiry check.
+# CK's token lasts 7 days and the operator reauths on a 7-day cadence, so the
+# margin is hours: a reauth that silently fails to mint a new token means a
+# failed run the next morning (2026-07-28). Warn while there is still time.
+# `cksession` is in ALERT_COVERED, so the alert clears itself after a good reauth.
+echo ""
+echo "=== Checking Comics Kingdom session expiry ==="
+if python scripts/check_ck_session.py; then
+    :
+else
+    FAILURES+=("Comics Kingdom session expiring")
+    FAILED_KEYS+=("cksession:expiry")
+fi
 
 # Phase 3: Commit and push everything that succeeded.
 # Recovery on push rejection: save same-day scrape JSONs to a staging dir, reset

--- a/scripts/reauth_comicskingdom.py
+++ b/scripts/reauth_comicskingdom.py
@@ -5,8 +5,16 @@ Re-authentication helper for Comics Kingdom.
 Seeds the persistent Chrome profile at ~/.comicskingdom_chrome_profile by
 opening a visible Chrome window, letting the operator type credentials and
 log in, and then closing the window so Chrome persists the session into
-the profile. Run this when the session expires (typically every ~60 days,
-or when the daily scrape reports "profile has no stored session").
+the profile.
+
+CK's token lasts **7 days**, and the operator reauths weekly -- so the margin
+is hours, and a reauth that silently fails to mint a new token means a failed
+run the next morning (2026-07-28). This script therefore reads the token expiry
+before and after login and tells you whether it actually moved. Trust that
+line, not the browser looking logged in.
+
+Let this script close the browser. Closing the window by hand can leave Chrome's
+new cookies unflushed, which produces exactly that silent failure.
 """
 
 import sys
@@ -14,10 +22,13 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from datetime import datetime, timezone
+
 from scripts.comicskingdom_scraper_individual import (
     setup_driver,
     wait_for_manual_login,
 )
+from scripts.check_ck_session import describe_renewal, read_token_expiry
 
 
 PROFILE_DIR = Path.home() / '.comicskingdom_chrome_profile'
@@ -42,6 +53,13 @@ def main():
 
     input("Press ENTER to continue...")
 
+    # Recorded now so we can prove the login actually issued a new token.
+    expiry_before = read_token_expiry(PROFILE_DIR)
+    if expiry_before:
+        print(f"\n📅 Current session expires: {expiry_before:%Y-%m-%d %H:%M UTC}")
+    else:
+        print("\n📅 No existing session token found (fresh profile).")
+
     print("\n🌐 Opening browser with persistent profile...")
     driver = setup_driver(show_browser=True, use_profile=True)
 
@@ -51,11 +69,21 @@ def main():
             print("✅ SUCCESS! Re-authentication complete")
             print("="*80)
             print(f"\nProfile seeded at: {PROFILE_DIR}")
-            print("The daily scrape will pick up this session on its next run.")
             print("No pickled cookies were written.")
             print("="*80 + "\n")
+
+            # Quit first: Chrome writes cookies to disk on clean shutdown, so
+            # reading before this would see the pre-login state.
             driver.quit()
-            return 0
+
+            renewed, message = describe_renewal(
+                expiry_before, read_token_expiry(PROFILE_DIR),
+                datetime.now(timezone.utc),
+            )
+            print("="*80)
+            print(f"{'✅' if renewed else '❌'} {message}")
+            print("="*80 + "\n")
+            return 0 if renewed else 1
         else:
             print("\n❌ Re-authentication failed")
             driver.quit()

--- a/scripts/report_pipeline_failures.py
+++ b/scripts/report_pipeline_failures.py
@@ -53,6 +53,22 @@ SOURCE_NAMES = {
     "push": "Git push",
     "preflight": "SSH preflight",
     "heartbeat": "Daily pipeline",
+    "cksession": "Comics Kingdom session",
+}
+
+# A few alerts are warnings rather than failures, and read badly through the
+# generic "<name> <kind> failed" template.
+TITLE_OVERRIDES = {
+    "cksession": "[pipeline] Comics Kingdom session needs a reauth",
+}
+
+LEAD_OVERRIDES = {
+    "cksession": (
+        "The Comics Kingdom session token is close to expiring. CK issues a "
+        "7-day token, so a run will start failing within days if it is not "
+        "renewed.\n\nRun `python scripts/reauth_comicskingdom.py` on the host; "
+        "it now confirms whether the expiry actually moved."
+    ),
 }
 
 
@@ -83,13 +99,18 @@ def display_name(slug: str) -> str:
 
 
 def issue_title(slug: str, kind: str) -> str:
+    if slug in TITLE_OVERRIDES:
+        return TITLE_OVERRIDES[slug]
     return f"[pipeline] {display_name(slug)} {kind} failed"
 
 
 def issue_body(slug: str, kind: str, run: str, date: str, detail: str) -> str:
-    body = (
+    lead = LEAD_OVERRIDES.get(slug) or (
         f"The {run} pipeline run on {date} reported a **{kind}** failure for "
-        f"**{display_name(slug)}**.\n\n"
+        f"**{display_name(slug)}**."
+    )
+    body = (
+        f"{lead}\n\n"
         f"- Source: {display_name(slug)} (`{slug}`)\n"
         f"- Failure: {kind}\n"
         f"- Run: {run}\n"

--- a/tests/test_check_ck_session.py
+++ b/tests/test_check_ck_session.py
@@ -1,0 +1,230 @@
+"""Tests for check_ck_session.py.
+
+Uses a real temporary SQLite database shaped like Chrome's cookie store, so
+these exercise the actual query path without mocking sqlite and without
+touching the operator's real profile.
+"""
+
+import os
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from scripts.check_ck_session import (
+    CK_HOST,
+    DEFAULT_WARN_DAYS,
+    TOKEN_NAME,
+    chrome_time_to_datetime,
+    datetime_to_chrome_time,
+    days_remaining,
+    describe_renewal,
+    evaluate,
+    main,
+    read_token_expiry,
+)
+
+
+NOW = datetime(2026, 7, 28, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def make_profile(tmp_path, cookies):
+    """Build a Chrome-shaped profile dir. `cookies` is (host, name, expiry_dt)."""
+    default = tmp_path / 'Default'
+    default.mkdir(parents=True, exist_ok=True)
+    db = default / 'Cookies'
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE cookies (host_key TEXT, name TEXT, expires_utc INTEGER, "
+        "is_persistent INTEGER)"
+    )
+    for host, name, expiry in cookies:
+        conn.execute(
+            "INSERT INTO cookies VALUES (?, ?, ?, ?)",
+            (host, name, datetime_to_chrome_time(expiry) if expiry else 0,
+             1 if expiry else 0),
+        )
+    conn.commit()
+    conn.close()
+    return tmp_path
+
+
+class TestChromeTimeConversion:
+    def test_roundtrips(self):
+        when = datetime(2026, 8, 4, 11, 21, 25, tzinfo=timezone.utc)
+        assert chrome_time_to_datetime(datetime_to_chrome_time(when)) == when
+
+    def test_known_chrome_epoch_value(self):
+        """Chrome counts microseconds from 1601-01-01."""
+        assert chrome_time_to_datetime(11644473600 * 1_000_000) == datetime(
+            1970, 1, 1, tzinfo=timezone.utc
+        )
+
+    def test_zero_is_session_cookie(self):
+        assert chrome_time_to_datetime(0) is None
+
+
+class TestReadTokenExpiry:
+    def test_reads_the_auth_token_expiry(self, tmp_path):
+        expiry = datetime(2026, 8, 4, 11, 21, 25, tzinfo=timezone.utc)
+        profile = make_profile(tmp_path, [(CK_HOST, TOKEN_NAME, expiry)])
+        assert read_token_expiry(profile) == expiry
+
+    def test_ignores_other_cookies(self, tmp_path):
+        expiry = datetime(2026, 8, 4, tzinfo=timezone.utc)
+        profile = make_profile(tmp_path, [
+            (CK_HOST, '_ga', datetime(2027, 1, 1, tzinfo=timezone.utc)),
+            (CK_HOST, TOKEN_NAME, expiry),
+        ])
+        assert read_token_expiry(profile) == expiry
+
+    def test_ignores_the_same_name_on_another_host(self, tmp_path):
+        profile = make_profile(tmp_path, [
+            ('g010.comicskingdom.com', TOKEN_NAME,
+             datetime(2027, 1, 1, tzinfo=timezone.utc)),
+        ])
+        assert read_token_expiry(profile) is None
+
+    def test_returns_none_when_token_absent(self, tmp_path):
+        profile = make_profile(tmp_path, [(CK_HOST, '_ga', None)])
+        assert read_token_expiry(profile) is None
+
+    def test_returns_none_when_profile_missing(self, tmp_path):
+        assert read_token_expiry(tmp_path / 'nope') is None
+
+    def test_does_not_mutate_the_profile(self, tmp_path):
+        """Must be safe to run against a profile Chrome may be using."""
+        expiry = datetime(2026, 8, 4, tzinfo=timezone.utc)
+        profile = make_profile(tmp_path, [(CK_HOST, TOKEN_NAME, expiry)])
+        db = profile / 'Default' / 'Cookies'
+        before = db.stat().st_mtime, db.stat().st_size
+        read_token_expiry(profile)
+        assert (db.stat().st_mtime, db.stat().st_size) == before
+
+
+class TestDaysRemaining:
+    def test_counts_forward(self):
+        assert days_remaining(NOW + timedelta(days=7), NOW) == pytest.approx(7.0)
+
+    def test_negative_when_expired(self):
+        assert days_remaining(NOW - timedelta(days=1), NOW) == pytest.approx(-1.0)
+
+    def test_fractional(self):
+        assert days_remaining(NOW + timedelta(hours=12), NOW) == pytest.approx(0.5)
+
+
+class TestEvaluate:
+    def test_fresh_token_is_ok(self):
+        status, _ = evaluate(NOW + timedelta(days=7), NOW, DEFAULT_WARN_DAYS)
+        assert status == 'ok'
+
+    def test_token_inside_warn_window_is_expiring(self):
+        status, _ = evaluate(NOW + timedelta(days=1), NOW, DEFAULT_WARN_DAYS)
+        assert status == 'expiring'
+
+    def test_already_expired_is_expired(self):
+        status, _ = evaluate(NOW - timedelta(hours=1), NOW, DEFAULT_WARN_DAYS)
+        assert status == 'expired'
+
+    def test_missing_token_is_missing(self):
+        status, _ = evaluate(None, NOW, DEFAULT_WARN_DAYS)
+        assert status == 'missing'
+
+    def test_boundary_exactly_at_threshold_is_expiring(self):
+        status, _ = evaluate(NOW + timedelta(days=2), NOW, 2)
+        assert status == 'expiring'
+
+    def test_detail_reports_days_and_date(self):
+        _, detail = evaluate(NOW + timedelta(days=7), NOW, DEFAULT_WARN_DAYS)
+        assert '7.0' in detail
+        assert '2026-08-04' in detail
+
+    def test_detail_for_missing_token_mentions_reauth(self):
+        _, detail = evaluate(None, NOW, DEFAULT_WARN_DAYS)
+        assert 'reauth' in detail.lower()
+
+    def test_warn_window_matches_a_seven_day_token(self):
+        """A 7-day token on a 7-day cadence needs warning before the run fails."""
+        assert 1 <= DEFAULT_WARN_DAYS <= 3
+
+
+class TestDescribeRenewal:
+    """The 2026-07-28 failure mode: a reauth that looked fine but didn't stick."""
+
+    def test_expiry_moved_forward_is_renewed(self):
+        before = NOW + timedelta(days=1)
+        after = NOW + timedelta(days=7)
+        renewed, message = describe_renewal(before, after, NOW)
+        assert renewed is True
+        assert '7.0' in message
+
+    def test_unchanged_expiry_is_not_renewed(self):
+        same = NOW + timedelta(hours=6)
+        renewed, message = describe_renewal(same, same, NOW)
+        assert renewed is False
+        assert 'did NOT move' in message
+
+    def test_expiry_going_backwards_is_not_renewed(self):
+        renewed, _ = describe_renewal(NOW + timedelta(days=7),
+                                      NOW + timedelta(days=1), NOW)
+        assert renewed is False
+
+    def test_missing_token_after_login_is_not_renewed(self):
+        renewed, message = describe_renewal(NOW + timedelta(days=1), None, NOW)
+        assert renewed is False
+        assert 'did NOT persist' in message
+
+    def test_first_ever_login_counts_as_renewed(self):
+        """No prior token is normal on a fresh profile, not a failure."""
+        renewed, _ = describe_renewal(None, NOW + timedelta(days=7), NOW)
+        assert renewed is True
+
+    def test_failure_message_tells_the_operator_what_to_do(self):
+        same = NOW + timedelta(hours=6)
+        assert 're-run' in describe_renewal(same, same, NOW)[1].lower()
+
+
+class TestMain:
+    def test_exit_zero_when_healthy(self, tmp_path, capsys):
+        profile = make_profile(tmp_path, [
+            (CK_HOST, TOKEN_NAME, datetime.now(timezone.utc) + timedelta(days=7)),
+        ])
+        assert main(['--profile', str(profile)]) == 0
+        assert 'ok' in capsys.readouterr().out.lower()
+
+    def test_exit_nonzero_when_expiring(self, tmp_path):
+        profile = make_profile(tmp_path, [
+            (CK_HOST, TOKEN_NAME, datetime.now(timezone.utc) + timedelta(hours=6)),
+        ])
+        assert main(['--profile', str(profile)]) == 1
+
+    def test_exit_nonzero_when_missing(self, tmp_path):
+        profile = make_profile(tmp_path, [(CK_HOST, '_ga', None)])
+        assert main(['--profile', str(profile)]) == 1
+
+    def test_warn_days_is_configurable(self, tmp_path):
+        profile = make_profile(tmp_path, [
+            (CK_HOST, TOKEN_NAME, datetime.now(timezone.utc) + timedelta(days=4)),
+        ])
+        assert main(['--profile', str(profile), '--warn-days', '2']) == 0
+        assert main(['--profile', str(profile), '--warn-days', '6']) == 1
+
+    def test_quiet_suppresses_output_but_keeps_exit_code(self, tmp_path, capsys):
+        profile = make_profile(tmp_path, [
+            (CK_HOST, TOKEN_NAME, datetime.now(timezone.utc) + timedelta(days=7)),
+        ])
+        assert main(['--profile', str(profile), '--quiet']) == 0
+        assert capsys.readouterr().out == ''
+
+    def test_detail_flag_prints_only_the_detail_line(self, tmp_path, capsys):
+        """The pipeline pipes this straight into the alert body."""
+        profile = make_profile(tmp_path, [
+            (CK_HOST, TOKEN_NAME, datetime.now(timezone.utc) + timedelta(hours=6)),
+        ])
+        main(['--profile', str(profile), '--detail-only'])
+        out = capsys.readouterr().out.strip()
+        assert out
+        assert '\n' not in out

--- a/tests/test_comicskingdom_scraper.py
+++ b/tests/test_comicskingdom_scraper.py
@@ -429,15 +429,24 @@ class TestReauthScript:
             for n in ast.walk(tree)
         )
 
-    def test_exits_zero_on_login_success(self, monkeypatch, tmp_path):
+    def test_exits_zero_when_login_mints_a_new_token(self, monkeypatch, tmp_path):
+        """Success requires a *new* token on disk, not just a login that looked fine.
+
+        A reauth performed while the old session is still valid can leave the
+        old expiry untouched; that is not success (2026-07-28 outage).
+        """
+        from datetime import datetime, timedelta, timezone
+
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.setattr("builtins.input", lambda *_a, **_kw: "")
 
         reauth = self._load_reauth_module()
 
         driver = MagicMock()
+        fresh = datetime.now(timezone.utc) + timedelta(days=7)
         with patch.object(reauth, "setup_driver", return_value=driver) as ms, \
-             patch.object(reauth, "wait_for_manual_login", return_value=True) as ml:
+             patch.object(reauth, "wait_for_manual_login", return_value=True) as ml, \
+             patch.object(reauth, "read_token_expiry", side_effect=[None, fresh]):
             result = reauth.main()
 
         assert result == 0
@@ -448,6 +457,66 @@ class TestReauthScript:
         assert kwargs.get("show_browser") is True
         # login helper was invoked with only the driver (no JS-filled creds)
         ml.assert_called_once_with(driver)
+
+    def test_exits_nonzero_when_the_expiry_does_not_move(self, monkeypatch, tmp_path):
+        """The 2026-07-28 failure: login looked fine, no new token was issued."""
+        from datetime import datetime, timedelta, timezone
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr("builtins.input", lambda *_a, **_kw: "")
+
+        reauth = self._load_reauth_module()
+
+        stale = datetime.now(timezone.utc) + timedelta(hours=6)
+        with patch.object(reauth, "setup_driver", return_value=MagicMock()), \
+             patch.object(reauth, "wait_for_manual_login", return_value=True), \
+             patch.object(reauth, "read_token_expiry", side_effect=[stale, stale]):
+            result = reauth.main()
+
+        assert result == 1
+
+    def test_exits_nonzero_when_no_token_lands_on_disk(self, monkeypatch, tmp_path):
+        """Chrome closed without flushing cookies — the leading 07-28 hypothesis."""
+        from datetime import datetime, timedelta, timezone
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr("builtins.input", lambda *_a, **_kw: "")
+
+        reauth = self._load_reauth_module()
+
+        old = datetime.now(timezone.utc) + timedelta(hours=6)
+        with patch.object(reauth, "setup_driver", return_value=MagicMock()), \
+             patch.object(reauth, "wait_for_manual_login", return_value=True), \
+             patch.object(reauth, "read_token_expiry", side_effect=[old, None]):
+            result = reauth.main()
+
+        assert result == 1
+
+    def test_reads_the_expiry_after_quitting_the_browser(self, monkeypatch, tmp_path):
+        """Chrome flushes cookies on clean shutdown, so order matters."""
+        from datetime import datetime, timedelta, timezone
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr("builtins.input", lambda *_a, **_kw: "")
+
+        reauth = self._load_reauth_module()
+
+        order = []
+        driver = MagicMock()
+        driver.quit.side_effect = lambda: order.append("quit")
+        fresh = datetime.now(timezone.utc) + timedelta(days=7)
+
+        def read(_profile):
+            order.append("read")
+            return fresh
+
+        with patch.object(reauth, "setup_driver", return_value=driver), \
+             patch.object(reauth, "wait_for_manual_login", return_value=True), \
+             patch.object(reauth, "read_token_expiry", side_effect=read):
+            reauth.main()
+
+        # first read is the "before" snapshot, then quit, then the "after" read
+        assert order == ["read", "quit", "read"]
 
     def test_exits_nonzero_on_login_fail(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HOME", str(tmp_path))

--- a/tests/test_report_pipeline_failures.py
+++ b/tests/test_report_pipeline_failures.py
@@ -352,6 +352,30 @@ class TestMain:
         assert '<details>' not in body
 
 
+class TestAlertWording:
+    """Some alerts are warnings, not failures, and need their own wording."""
+
+    def test_session_alert_title_avoids_the_failed_template(self):
+        title = issue_title('cksession', 'expiry')
+        assert 'failed' not in title
+        assert 'reauth' in title.lower()
+
+    def test_session_alert_body_says_what_to_run(self):
+        body = issue_body('cksession', 'expiry', 'pass1', '2026-07-28', '')
+        assert 'reauth_comicskingdom.py' in body
+        assert '7-day' in body
+
+    def test_session_alert_keeps_its_marker(self, gh_mock):
+        report(['cksession'], {'cksession': 'expiry'}, run='pass1', date='2026-07-28')
+        created = calls_of(gh_mock, 'issue', 'create')[0]
+        assert f'{MARKER_PREFIX}cksession' in created[created.index('--body') + 1]
+
+    def test_ordinary_sources_keep_the_default_template(self):
+        assert issue_title('tinyview', 'scrape') == '[pipeline] TinyView scrape failed'
+        body = issue_body('tinyview', 'scrape', 'pass1', '2026-07-28', '')
+        assert 'reported a **scrape** failure' in body
+
+
 class TestSourceNames:
     def test_every_pipeline_slug_has_a_display_name(self):
         expected = {


### PR DESCRIPTION
## Why

Yesterday's outage. CK's token lasts **exactly 7 days** — I measured it from the cookie rather than inferring it from failure dates — and the reauth cadence is also 7 days. The margin is hours.

On 2026-07-27 the Monday reauth didn't mint a new token, and 2026-07-28's run failed. Nothing warned in between, because **nothing ever looked at the expiry**. The browser shows a logged-in page whether or not a new token was written, so a reauth that silently does nothing looks exactly like one that worked.

Root cause of Monday specifically is undetermined — this morning's reauth overwrote the evidence. Rather than guess, this makes the failure mode *observable* regardless of cause.

## What

**`scripts/check_ck_session.py`** — reads the expiry from the Chrome cookie store. Copies the DB before querying, so it's safe while Chrome holds the profile and never mutates the live session.

```
$ python scripts/check_ck_session.py
✅ Comics Kingdom session ok: 7.0 days remaining (2026-08-04 11:30 UTC).
```

**`reauth_comicskingdom.py`** — records the expiry before and after login and reports whether it *actually moved*:

```
✅ Session renewed: expires 2026-08-04 11:21 UTC (7.0 days from now).
❌ Session expiry did NOT move (still ...). Re-run the reauth.
```

It reads **after** `driver.quit()`, because Chrome only flushes cookies on clean shutdown — which is also why closing the window by hand is the leading hypothesis for Monday.

**Daily alert** — the run opens `[pipeline] Comics Kingdom session needs a reauth` when fewer than 2 days remain. `cksession` is in `ALERT_COVERED`, so it auto-closes after a good reauth. This would have fired ~18h before yesterday's outage.

## Note on a changed test

The reauth script's exit-code contract is now stricter: **a login that leaves no new token on disk is a failure.** `test_exits_zero_on_login_success` asserted the old, weaker contract ("login returned True → exit 0") and would have passed straight through Monday's bug. It's been renamed and updated, with tests added for both silent-failure modes and one pinning the read-after-quit ordering.

## Testing

32 new tests using a real temporary SQLite database shaped like Chrome's cookie store — exercises the actual query path, no sqlite mocking, never touches the real profile. Verified against the live profile (7.0 days). Full suite: **436 passed**.

## Not done

Cadence unchanged at 7 days, per your preference. This adds verification rather than lengthening the interval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MRMLtUKyM8XfrbGQqNT4t