### PR TITLE
fix: never report success for a push that published nothing

### DIFF
--- a/docs/solutions/logic-errors/pipeline-silent-failure-on-wrong-branch.md
+++ b/docs/solutions/logic-errors/pipeline-silent-failure-on-wrong-branch.md
@@ -1,0 +1,112 @@
+---
+title: Pipeline reported ALL SUCCESS while publishing nothing (wrong branch)
+date: 2026-07-28
+category: logic-errors
+module: pipeline
+problem_type: bug
+component: scripts/local_master_update.sh
+severity: high
+applies_when:
+  - "A run logs '✅ Successfully pushed' and 'ALL SUCCESS' but feeds on the site are stale"
+  - "`git push origin main` prints 'Everything up-to-date' during a pipeline run"
+  - "A feed commit exists locally on a branch that is not main"
+  - "A local feature branch was silently reset to origin/main"
+tags: [git, branch, silent-failure, false-success, push-verification, launchd]
+stack: [bash, git]
+---
+
+## Problem
+
+On 2026-07-28 the 13:00 Pass 2 run reported:
+
+```
+[feat/ck-session-expiry-check 17a2020c5] Pass 2 GoComics feed update for 2026-07-28
+ 347 files changed, 1399 insertions(+), 1300 deletions(-)
+Everything up-to-date
+✅ Successfully pushed pass-2 updates
+ComicCaster Pass 2 Complete (ALL SUCCESS)
+```
+
+Every line is technically true and the conclusion is wrong. **The feed update
+never reached subscribers.** No alert fired, because from the script's point of
+view nothing failed.
+
+## Root cause
+
+The repo had been left checked out on a feature branch. Both pipeline scripts
+assume `main` and never check:
+
+1. `git reset --hard origin/main` — with HEAD on a feature branch, this moves
+   *that branch's* pointer to origin/main. Any local commit on it is discarded
+   (survives only if already pushed).
+2. `git commit` — the feed commit lands on the feature branch.
+3. `git push origin main` — pushes the local **`main`** ref, which nobody
+   touched. Nothing to send, so git prints "Everything up-to-date" and **exits
+   0**. The script reads exit 0 as "published".
+
+The bug is the assumption that `git push` exiting 0 means *your commit* was
+published. It only means the named ref had nothing to send.
+
+## Fix
+
+Two independent guards, because either alone leaves a hole.
+
+**1. Branch guard** — refuse to operate on the wrong branch:
+
+```bash
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+if [ "$CURRENT_BRANCH" != "main" ]; then
+    if git checkout main; then
+        FAILED_KEYS+=("branch:wrongbranch")   # warn, then continue
+    else
+        report_pipeline_failures "branch" "branch:checkout"
+        exit 0                                 # never reset --hard elsewhere
+    fi
+fi
+```
+
+Deliberately *not* `checkout -f`: discarding someone's uncommitted branch work
+is worse than skipping a run, so a blocked checkout aborts loudly instead.
+
+**2. Push verification** — prove the commit is actually on the remote:
+
+```bash
+verify_push_landed() {
+    git fetch -q origin main 2>/dev/null || return 1
+    git merge-base --is-ancestor HEAD origin/main 2>/dev/null
+}
+```
+
+Applied at every push site as `push_with_watchdog && verify_push_landed`. This
+is the load-bearing one: it catches *any* cause of "pushed but not published,"
+not just the branch case.
+
+Verified against a scratch repo reproducing the exact scenario — commit on a
+feature branch, `push origin main` succeeds with nothing to send, and
+`verify_push_landed` returns 1 where the old code returned success.
+
+## Recovery, if it already happened
+
+The stranded commit's parent is origin/main, so a fast-forward publishes it
+unchanged:
+
+```bash
+git checkout main
+git merge --ff-only <stranded-sha>
+git push origin main
+git branch -f <feature-branch> origin/<feature-branch>   # restore from remote
+```
+
+## Lesson
+
+**A zero exit code answers the question the command was asked, not the question
+you meant.** `git push origin main` was asked "is origin/main up to date with
+local main?" — not "did my work get published?" Wherever a step's success is
+inferred from an exit code, ask what that code literally asserts, and if the
+gap matters, verify the postcondition directly.
+
+This is also the one failure class the alerting system cannot catch by design:
+it only reports steps that fail. A step that succeeds at the wrong thing is
+invisible to it. The pipeline heartbeat would have caught it eventually — no
+pipeline commit on main for 20h — but only after a full day of stale feeds.
+Postcondition checks belong next to the steps themselves.

--- a/scripts/local_master_update.sh
+++ b/scripts/local_master_update.sh
@@ -35,7 +35,7 @@ FAILED_KEYS=()
 # Pass 1 covers everything; Pass 2 covers GoComics only.
 # `preflight` is included because reaching the end of a run proves it passed,
 # which is what auto-closes a preflight issue from a previous run.
-ALERT_COVERED="gocomics,comicskingdom,tinyview,newyorker,farside,creators,mrboffo,push,preflight,cksession"
+ALERT_COVERED="gocomics,comicskingdom,tinyview,newyorker,farside,creators,mrboffo,push,preflight,cksession,branch"
 
 # Load environment variables (.env has GoComics credentials)
 if [ -f "$REPO_DIR/.env" ]; then
@@ -99,6 +99,35 @@ if ! ssh -T "$SSH_HOST" 2>&1 | grep -q "successfully authenticated"; then
     exit 0  # Exit 0 so LaunchD doesn't retry endlessly
 fi
 echo "✅ GitHub SSH authentication verified"
+
+# Branch guard.
+# The LaunchAgents fire regardless of what is checked out, and everything below
+# assumes main: the sync resets --hard to origin/main, and Phase 3 pushes the
+# local `main` ref. Run this on any other branch and the failure is SILENT --
+# the reset moves the *feature branch* pointer, the commit lands on that branch,
+# and `git push origin main` pushes an unchanged main and reports "Everything
+# up-to-date" as success. That is exactly what happened on 2026-07-28: a full
+# Pass 2 feed update never reached subscribers and the run declared ALL SUCCESS.
+#
+# Switch back to main rather than abort, so a forgotten checkout costs a warning
+# instead of a day of stale feeds. Deliberately NOT `checkout -f`: discarding
+# someone's uncommitted branch work is worse than skipping a run, so a checkout
+# that cannot proceed aborts loudly instead.
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+if [ "$CURRENT_BRANCH" != "main" ]; then
+    echo "⚠️  Repo is on '$CURRENT_BRANCH', not main -- switching before syncing"
+    if git checkout main; then
+        echo "✅ Switched to main (was on '$CURRENT_BRANCH')"
+        FAILURES+=("repo was left on branch '$CURRENT_BRANCH'")
+        FAILED_KEYS+=("branch:wrongbranch")
+    else
+        echo "❌ Could not switch to main from '$CURRENT_BRANCH' -- aborting"
+        echo "   Refusing to reset --hard while on another branch."
+        report_pipeline_failures "branch" "branch:checkout"
+        echo "ComicCaster ABORTED (wrong branch) - $(date)"
+        exit 0
+    fi
+fi
 
 # Sync local main with origin.
 # Policy: local main must exactly match origin/main at the start of each run.
@@ -332,6 +361,24 @@ push_with_watchdog() {
     fi
 }
 
+# verify_push_landed: confirm the commit we just made is genuinely reachable from
+# origin/main. `git push` exiting 0 is NOT proof of publication -- pushing a ref
+# that has nothing new prints "Everything up-to-date" and succeeds, which on
+# 2026-07-28 turned an unpublished feed update into a reported ALL SUCCESS.
+# Fetch first so origin/main reflects the remote rather than a stale local ref.
+verify_push_landed() {
+    if ! git fetch -q origin main 2>/dev/null; then
+        echo "⚠️  Could not fetch to verify the push landed"
+        return 1
+    fi
+    if git merge-base --is-ancestor HEAD origin/main 2>/dev/null; then
+        echo "✅ Verified: $(git rev-parse --short HEAD) is on origin/main"
+        return 0
+    fi
+    echo "❌ Push reported success but $(git rev-parse --short HEAD) is NOT on origin/main"
+    return 1
+}
+
 git add -f data/*.json public/feeds/*.xml
 
 if git diff --staged --quiet; then
@@ -342,7 +389,7 @@ else
 Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>"
 
     PUSH_OK=false
-    if push_with_watchdog; then
+    if push_with_watchdog && verify_push_landed; then
         echo "✅ Successfully pushed all updates"
         PUSH_OK=true
     else
@@ -406,7 +453,7 @@ Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.g
 
 Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>"
 
-            if push_with_watchdog; then
+            if push_with_watchdog && verify_push_landed; then
                 echo "✅ Successfully pushed recovery commit"
                 PUSH_OK=true
             else
@@ -419,7 +466,7 @@ Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.g
 
     if [ "$PUSH_OK" = false ]; then
         FAILURES+=("Git push")
-        FAILED_KEYS+=("push:push")
+        FAILED_KEYS+=("push:verification")
     fi
 fi
 

--- a/scripts/local_pass2_update.sh
+++ b/scripts/local_pass2_update.sh
@@ -42,7 +42,7 @@ FAILED_KEYS=()
 
 # Pass 2 examines GoComics only. This list is what the reporter may auto-close,
 # so it must NOT name the other sources -- they are untouched here, not healthy.
-ALERT_COVERED="gocomics,push,preflight"
+ALERT_COVERED="gocomics,push,preflight,branch"
 
 # Load environment variables (.env has GoComics credentials)
 if [ -f "$REPO_DIR/.env" ]; then
@@ -121,6 +121,28 @@ stage_touched_files() {
     git add -f public/feeds/*.xml
 }
 
+# Branch guard -- same rationale as local_master_update.sh. Everything below
+# assumes main: the reset below and the `git push origin main` in Phase 3. On any
+# other branch the failure is SILENT -- the reset moves that branch's pointer, the
+# commit lands there, and pushing an unchanged main reports "Everything
+# up-to-date" as success. On 2026-07-28 this pass did exactly that and a full
+# feed update never reached subscribers while the run declared ALL SUCCESS.
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+if [ "$CURRENT_BRANCH" != "main" ]; then
+    echo "⚠️  Repo is on '$CURRENT_BRANCH', not main -- switching before syncing"
+    if git checkout main; then
+        echo "✅ Switched to main (was on '$CURRENT_BRANCH')"
+        FAILURES+=("repo was left on branch '$CURRENT_BRANCH'")
+        FAILED_KEYS+=("branch:wrongbranch")
+    else
+        echo "❌ Could not switch to main from '$CURRENT_BRANCH' -- aborting"
+        echo "   Refusing to reset --hard while on another branch."
+        report_pipeline_failures "branch" "branch:checkout"
+        echo "ComicCaster Pass 2 ABORTED (wrong branch) - $(date)"
+        exit 0
+    fi
+fi
+
 # Reset to origin/main before starting. Any uncommitted work or divergent
 # local commits will be discarded — same policy as the master script.
 git fetch origin
@@ -173,6 +195,24 @@ push_with_watchdog() {
     fi
 }
 
+# verify_push_landed: confirm the commit we just made is genuinely reachable from
+# origin/main. `git push` exiting 0 is NOT proof of publication -- pushing a ref
+# that has nothing new prints "Everything up-to-date" and succeeds, which on
+# 2026-07-28 turned an unpublished feed update into a reported ALL SUCCESS.
+# Fetch first so origin/main reflects the remote rather than a stale local ref.
+verify_push_landed() {
+    if ! git fetch -q origin main 2>/dev/null; then
+        echo "⚠️  Could not fetch to verify the push landed"
+        return 1
+    fi
+    if git merge-base --is-ancestor HEAD origin/main 2>/dev/null; then
+        echo "✅ Verified: $(git rev-parse --short HEAD) is on origin/main"
+        return 0
+    fi
+    echo "❌ Push reported success but $(git rev-parse --short HEAD) is NOT on origin/main"
+    return 1
+}
+
 stage_touched_files
 
 if git diff --staged --quiet; then
@@ -184,7 +224,7 @@ Captures late-publishing political cartoonists missed by the 03:20 PT
 pass-1 scrape. See docs/solutions/logic-errors/gocomics-favorites-page-timing.md."
 
     PUSH_OK=false
-    if push_with_watchdog; then
+    if push_with_watchdog && verify_push_landed; then
         echo "✅ Successfully pushed pass-2 updates"
         PUSH_OK=true
     else
@@ -221,7 +261,7 @@ pass-1 scrape. See docs/solutions/logic-errors/gocomics-favorites-page-timing.md
             PUSH_OK=true
         else
             git commit -m "Pass 2 GoComics feed update for $DATE_STR (recovery after push conflict)"
-            if push_with_watchdog; then
+            if push_with_watchdog && verify_push_landed; then
                 echo "✅ Successfully pushed pass-2 recovery commit"
                 PUSH_OK=true
             else
@@ -234,7 +274,7 @@ pass-1 scrape. See docs/solutions/logic-errors/gocomics-favorites-page-timing.md
 
     if [ "$PUSH_OK" = false ]; then
         FAILURES+=("Git push")
-        FAILED_KEYS+=("push:push")
+        FAILED_KEYS+=("push:verification")
     fi
 fi
 

--- a/scripts/report_pipeline_failures.py
+++ b/scripts/report_pipeline_failures.py
@@ -54,12 +54,14 @@ SOURCE_NAMES = {
     "preflight": "SSH preflight",
     "heartbeat": "Daily pipeline",
     "cksession": "Comics Kingdom session",
+    "branch": "Repo branch",
 }
 
 # A few alerts are warnings rather than failures, and read badly through the
 # generic "<name> <kind> failed" template.
 TITLE_OVERRIDES = {
     "cksession": "[pipeline] Comics Kingdom session needs a reauth",
+    "branch": "[pipeline] Pipeline ran on the wrong branch",
 }
 
 LEAD_OVERRIDES = {
@@ -68,6 +70,16 @@ LEAD_OVERRIDES = {
         "7-day token, so a run will start failing within days if it is not "
         "renewed.\n\nRun `python scripts/reauth_comicskingdom.py` on the host; "
         "it now confirms whether the expiry actually moved."
+    ),
+    "branch": (
+        "The pipeline started with the repository checked out on a branch other "
+        "than `main`.\n\nThis matters because the run resets `--hard` to "
+        "origin/main and then pushes the local `main` ref: on another branch the "
+        "commit lands there instead, and the push reports \"Everything "
+        "up-to-date\" as success while publishing nothing.\n\nThe run switched "
+        "back to `main` and continued. Check whether a feed commit was stranded "
+        "on the other branch:\n\n"
+        "```bash\ngit log --oneline -3 <branch>\n```"
     ),
 }
 

--- a/tests/test_report_pipeline_failures.py
+++ b/tests/test_report_pipeline_failures.py
@@ -370,6 +370,24 @@ class TestAlertWording:
         created = calls_of(gh_mock, 'issue', 'create')[0]
         assert f'{MARKER_PREFIX}cksession' in created[created.index('--body') + 1]
 
+    def test_wrong_branch_alert_explains_the_silent_failure(self):
+        title = issue_title('branch', 'wrongbranch')
+        assert 'wrong branch' in title.lower()
+        body = issue_body('branch', 'wrongbranch', 'pass2', '2026-07-28', '')
+        # Must tell the operator to go looking for a stranded feed commit.
+        assert 'up-to-date' in body
+        assert 'git log' in body
+
+    def test_push_verification_alert_reads_sensibly(self):
+        assert issue_title('push', 'verification') == (
+            '[pipeline] Git push verification failed'
+        )
+
+    def test_branch_alert_keeps_its_marker(self, gh_mock):
+        report(['branch'], {'branch': 'wrongbranch'}, run='pass2', date='2026-07-28')
+        created = calls_of(gh_mock, 'issue', 'create')[0]
+        assert f'{MARKER_PREFIX}branch' in created[created.index('--body') + 1]
+
     def test_ordinary_sources_keep_the_default_template(self):
         assert issue_title('tinyview', 'scrape') == '[pipeline] TinyView scrape failed'
         body = issue_body('tinyview', 'scrape', 'pass1', '2026-07-28', '')


### PR DESCRIPTION
## Why

Today's incident. The 13:00 Pass 2 run logged this:

```
[feat/ck-session-expiry-check 17a2020c5] Pass 2 GoComics feed update for 2026-07-28
 347 files changed, 1399 insertions(+), 1300 deletions(-)
Everything up-to-date
✅ Successfully pushed pass-2 updates
ComicCaster Pass 2 Complete (ALL SUCCESS)
```

Every line is true and the conclusion is wrong. **The feed update never reached subscribers**, and no alert fired — from the script's point of view nothing failed.

The repo was left on a feature branch (my fault). Both scripts assume `main` and never check:

1. `reset --hard origin/main` moved the *feature branch* pointer, discarding the local commit
2. the feed commit landed on that branch
3. `git push origin main` pushed an untouched local `main` → "Everything up-to-date" → **exit 0** → read as "published"

The real mistake is treating a zero exit from `git push` as proof *your commit* was published. It only asserts the named ref had nothing to send.

## What

**Branch guard** — switch back to `main` before anything destructive, and warn through the alerting so a forgotten checkout is visible rather than silent.

Deliberately *not* `checkout -f`. Discarding someone's uncommitted branch work is worse than skipping a run, so a blocked checkout aborts loudly instead of steamrolling it.

**`verify_push_landed`** — after every push, assert the commit is genuinely reachable from `origin/main`:

```bash
git fetch -q origin main && git merge-base --is-ancestor HEAD origin/main
```

Applied at all four push sites across both scripts. **This is the load-bearing half** — it catches any cause of "pushed but not published", not just the branch case.

## Verification

Reproduced the original scenario in a scratch repo:

```
=== CASE 1: commit pushed properly ===
✅ verified on origin/main          exit=0

=== CASE 2: commit on a feature branch, push main ===
  (push origin main: nothing to push)
❌ NOT on origin/main               exit=1   <-- old code called this SUCCESS
```

Full suite: **439 passed**.

## Why this class of bug matters

This is the one failure mode the alerting **cannot** catch by design: it reports steps that fail, and here a step succeeded at the wrong thing. The heartbeat would have caught it after 20h of no pipeline commits on `main` — but that's a full day of stale feeds. Postcondition checks belong next to the steps themselves.

Written up in `docs/solutions/logic-errors/pipeline-silent-failure-on-wrong-branch.md`, including the fast-forward recovery used today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MRMLtUKyM8XfrbGQqNT4t