### PR TITLE
ci: pin setup-chrome to @v2 in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Setup Chrome
-      uses: browser-actions/setup-chrome@latest
+      uses: browser-actions/setup-chrome@v2
       with:
         chrome-version: stable
 


### PR DESCRIPTION
## Why

`tests.yml` resolved `browser-actions/setup-chrome` at the floating `@latest` tag, while `update-feeds.yml` already pinned `@v2`.

Two problems with that:

1. **The gate isn't reproducible.** `tests.yml` is the workflow that gates every PR to `main`, and `main` auto-deploys to Netlify. A floating ref means that gate silently adopts whatever the action publishes next — a third-party action change can turn CI red (or, worse, green) with no commit here.
2. **Dependabot can't manage it.** The `github-actions` ecosystem is already configured in `.github/dependabot.yml`, but it can't propose an update for a ref with no version to compare against, so this one action sat outside the update flow that covers every other action in the repo.

## What

One-line change, pinning to `@v2` to match `update-feeds.yml`.

This PR's own CI run exercises the change — the tests job here is the pinned workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FbzH95RUbguw6ZrVuCk3n