### PR TITLE
chore(deps): put the shipped npm dependency under Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,12 @@ updates:
       prefix: "pip"
       include: "scope"
 
-  # Node.js dependencies (for Netlify functions)
+  # Node.js dependencies. rss-parser is declared in the root package.json and
+  # is what functions/fetch-feed.js resolves at build time, so "/" is the
+  # directory that actually covers shipped code. functions/package.json
+  # declares no dependencies of its own.
   - package-ecosystem: "npm"
-    directory: "/functions"
+    directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6,76 +6,7 @@
   "packages": {
     "": {
       "name": "comiccaster-functions",
-      "version": "1.0.0",
-      "dependencies": {
-        "rss": "^1.2.2",
-        "xml2js": "^0.6.2"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
-      "integrity": "sha512-5k547tI4Cy+Lddr/hdjNbBEWBwSl8EBc5aSdKvedav8DReADgWJzcYiktaRIw3GtGC1jjwldXtTzvqJZmtvC7w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
-      "integrity": "sha512-ryBDp1Z/6X90UvjUK3RksH0IBPM137T7cmg4OgD5wQBojlAiUwuok0QeELkim/72EtcYuNlmbkrcGuxj3Kl0YQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "~1.25.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/rss": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
-      "integrity": "sha512-xUhRTgslHeCBeHAqaWSbOYTydN2f0tAzNXvzh3stjz7QDhQMzdgHf3pfgNIngeytQflrFPfy6axHilTETr6gDg==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "2.1.13",
-        "xml": "1.0.1"
-      }
-    },
-    "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "license": "ISC"
-    },
-    "node_modules/xml": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
-      "license": "MIT"
-    },
-    "node_modules/xml2js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-      "license": "MIT",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      }
+      "version": "1.0.0"
     }
   }
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -3,8 +3,5 @@
   "version": "1.0.0",
   "description": "Netlify functions for ComicCaster",
   "main": "index.js",
-  "dependencies": {
-    "rss": "^1.2.2",
-    "xml2js": "^0.6.2"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
## The problem

Dependabot's npm ecosystem was pointed at `/functions`. But:

- `functions/package.json` declared **`rss`** and **`xml2js`** — a repo-wide grep finds **zero** `require()`/import of either.
- `functions/fetch-feed.js` requires **`rss-parser`**, which is declared only in the **root** `package.json` — and no Dependabot entry covered the root.

So npm updates were exactly inverted: two dead packages were under management, and the one npm package that actually ships was not.

## Verification that root is the live manifest

`GET https://comiccaster.xyz/.netlify/functions/fetch-feed` returns the function's **own** `405 {"error":"Method not allowed"}`, i.e. the handler executed. With `node_bundler = "esbuild"`, an unresolvable import fails at *build* time — so a deployed, executing function proves `rss-parser` resolves fine with the root declaration alone.

## The change

- `.github/dependabot.yml`: npm `directory` `/functions` → `/`
- `functions/package.json`: drop the two unused deps (lockfile regenerated; `npm audit` clean)

## Risk

The removal only touches packages nothing requires. The Netlify deploy preview on this PR rebuilds and re-bundles the functions — that build passing is the check that matters here, more than the Python suite. `pytest -v` is green locally regardless (491 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FbzH95RUbguw6ZrVuCk3n