### PR TITLE
deps: bump feedgen 0.9.0 -> 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 requests==2.34.2
 tls-client==1.0.1
 beautifulsoup4==4.15.0
-feedgen==0.9.0
+feedgen==1.0.0
 python-dotenv==1.2.3
 APScheduler==3.11.3
 selenium==4.47.0


### PR DESCRIPTION
## Why this one was stuck

`feedgen` builds **every feed this project serves** — `feed_generator.py`, `feed_aggregator.py`, `update_feeds.py` all import it. It's the highest-consequence pin in `requirements.txt`, and it had been frozen at 0.9.0 for 2.5 years without that being a decision anyone made:

- Dependabot proposed `0.1.0 → 1.0.0` in **PR #4**
- That PR was **closed unmerged on 2025-06-25** (same day as #19, requests-mock)
- Closing a Dependabot PR **permanently suppresses that version** — it was never re-offered
- 1.0.0 has been the latest release since **2023-12-25**

So it looked managed while being unmanageable.

## Verification

The unit suite mocks a lot of what matters here, so passing tests alone wouldn't justify a major bump. I generated real feed XML from real scraped data (`data/newyorker_2026-08-24.json`, 10 entries) under both versions and diffed:

```
0.9.0 → 7182 bytes
1.0.0 → 7182 bytes
normalized diff (generation timestamp masked) → IDENTICAL
```

The only textual difference between the two outputs is the `lastBuildDate`/`pubDate` clock, i.e. the second the probe ran.

- `pytest` on 1.0.0: **491 passed**
- `setup.py` already declares `feedgen>=0.9.0`, which admits 1.0.0 with no change

## Risk

Byte-identical output on real data is about as strong a signal as is available short of shipping — subscribers should see no change whatsoever. Merging also unfreezes the dependency: with the pin at 1.0.0, future releases become proposable again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FbzH95RUbguw6ZrVuCk3n