### PR TITLE
fix: give each source's run of a comic its own feed

### DIFF
--- a/docs/solutions/logic-errors/two-sources-one-feed-file-slug-collision.md
+++ b/docs/solutions/logic-errors/two-sources-one-feed-file-slug-collision.md
@@ -1,0 +1,144 @@
+---
+title: "Two sources, one feed file: a slug claimed twice flips the feed every pass"
+date: 2026-08-24
+category: logic-errors
+module: pipeline
+problem_type: silent-data-corruption
+component: generate_gocomics_feeds.py / generate_comicskingdom_feeds.py / public/comics_list.json
+severity: high
+applies_when:
+  - "A subscriber reports getting the same comic twice a day, or two interleaved storylines"
+  - "A feed's <guid> and <link> alternate host between the 03:05 and 13:00 commits"
+  - "Adding a comic that more than one source carries"
+  - "Bulk-importing a source catalog by stamping `source` onto existing entries"
+tags: [collision, slug, source-of-truth, catalog, gocomics, comicskingdom, feed-identity, reruns]
+stack: [python, json]
+github_prs: []
+---
+
+## TL;DR
+
+Every self-hosted feed lives at `public/feeds/<slug>.xml`, so a slug may be
+claimed by at most **one** feed-generating source. Four slugs were claimed by
+two. Both generators wrote the same path, pass 1 ended with Comics Kingdom and
+pass 2 ran GoComics alone, so the file alternated source twice a day forever.
+
+## How it looked from outside
+
+A subscriber to Edge City saw "two different storylines" interleaved and assumed
+it was upstream weirdness. Nothing was logged, no invariant fired, and every
+pipeline run reported ALL SUCCESS -- because every run *was* succeeding. It was
+writing the file correctly; it just wasn't the same file contents as six hours
+earlier.
+
+Git history makes it obvious once you look at one feed across commits:
+
+```
+08-24 03:21  comicskingdom.com     <- pass 1 (GoComics then Comics Kingdom)
+08-23 13:02  www.gocomics.com      <- pass 2 (GoComics only)
+08-23 03:20  comicskingdom.com
+08-22 13:02  www.gocomics.com
+```
+
+Because `<guid>` changes with the source, RSS readers treat each flip as a new
+item. Subscribers got every strip twice a day.
+
+## Root cause, in two layers
+
+**1. The catalog was self-contradictory.** Commit `11e401b688`
+("Add all Comics Kingdom comics", 2025-11-15) stamped `source: comicskingdom`
+onto entries that already existed as GoComics comics and left their `url`
+pointing at gocomics.com. The fingerprint -- `source` naming one host while
+`url` names another -- matched exactly 5 entries out of 600+.
+
+**2. Only one generator enforced ownership.** `generate_comicskingdom_feeds.py`
+had always filtered `c.get('source') == 'comicskingdom'`.
+`generate_gocomics_feeds.py` did not filter at all; `load_comics_catalog()`
+loaded every entry and called it "the full GoComics catalog." So GoComics wrote
+feeds for comics the catalog assigned elsewhere.
+
+Neither layer is visible on its own. The catalog looked fine if you only read
+`source`; the generator looked fine if you only read GoComics comics.
+
+## Distinguishing the two cases -- this is the part that matters
+
+When two sources carry "the same" comic, they are not necessarily carrying the
+same *work*, and the right fix differs:
+
+| | Same strip | Different runs |
+|---|---|---|
+| Example | Broom Hilda, Pluggers, Shoe | Edge City |
+| Fix | pick ONE source, drop the other | give each run its OWN slug |
+| Why | a second feed would duplicate | they are distinct works |
+
+**Do not guess which case you are in.** Compare the images. Perceptual
+correlation on downsampled greyscale is enough, and you need a *positive
+control* to know what a match scores:
+
+```python
+from PIL import Image
+def vec(path, n=64):
+    px = list(Image.open(path).convert("L").resize((n, n), Image.LANCZOS).getdata())
+    m = sum(px) / len(px)
+    sd = (sum((p - m) ** 2 for p in px) / len(px)) ** 0.5 or 1e-9
+    return [(p - m) / sd for p in px]
+corr = lambda a, b: sum(x * y for x, y in zip(a, b)) / len(a)
+```
+
+Results that settled it:
+
+- **Broom Hilda (control):** same-day r = **0.989-0.998**, best-match offset 0
+  on all 10 sampled days. That is what "identical" looks like.
+- **Edge City:** same-day r = 0.03-0.20, and the best match at *any* offset in a
+  +/-16 day window was r = 0.33 -- the noise floor. No lag explains it.
+
+The copyright line confirmed why: GoComics runs the **2011** sequence, Comics
+Kingdom the **2006** one. Both are reruns of different vintages.
+
+**A trap worth naming:** the printed date in the art (`7.10`, `7.7`) is
+day-month only. It cannot distinguish a three-day lag from a five-year-old
+rerun, and reading it that way produced a confidently wrong first diagnosis.
+The copyright year and the image comparison are the evidence; the strip date is
+not.
+
+## The fix
+
+- Catalog: the three identical comics went to GoComics (chosen on delivery
+  reliability -- 83/83 days vs 79-80/83 for Comics Kingdom over Jun-Aug).
+- Edge City keeps `edge-city` on GoComics so existing subscriptions survive, and
+  Comics Kingdom's run became `edge-city-classic`.
+- `generate_gocomics_feeds.py` grew `owned_by_gocomics()` and filters in
+  `main()` -- deliberately *not* in `load_comics_catalog()`, because an existing
+  test asserts that loader returns every entry from `public/` (that test guards
+  the 2026-05-16 dual-catalog fix and must keep its meaning).
+- New optional `source_slug`: the path a source serves the comic at, when it
+  differs from the slug we file it under. Defaults to `slug`.
+
+## Prevention
+
+`tests/test_catalog_source_integrity.py` now asserts:
+
+1. every entry declares a known source;
+2. `source` and `url` name the same host -- this is what would have caught
+   `11e401b688` on the day it landed;
+3. no slug is claimed by two feed-generating sources.
+
+All three are offline and run in the default suite.
+
+## Key insight
+
+A feed path is an identity. If two things can claim one identity, one of them is
+silently destroyed on every run, and the pipeline will report success while
+doing it -- the same shape as
+`docs/solutions/logic-errors/silent-empty-scrape-passed-as-success.md`. Assert
+the uniqueness of identity in a test, because no amount of per-source
+correctness gives it to you.
+
+## Related
+
+- `docs/solutions/logic-errors/gocomics-spanish-english-feed-contamination.md` --
+  the same class one layer down (English/Spanish strips colliding on a
+  badge-derived slug). Its "prefer canonical identifiers over derived ones" is
+  what `source_slug` implements.
+- `docs/plans/2026-05-16-001-fix-dual-catalog-source-of-truth-plan.md` -- why the
+  ownership filter lives in `main()` and not the loader.

--- a/public/comics_list.json
+++ b/public/comics_list.json
@@ -549,8 +549,7 @@
     "url": "https://www.gocomics.com/broomhilda",
     "slug": "broomhilda",
     "position": 69,
-    "is_updated": true,
-    "source": "comicskingdom"
+    "is_updated": true
   },
   {
     "name": "The Buckets",
@@ -958,8 +957,17 @@
     "url": "https://www.gocomics.com/edge-city",
     "slug": "edge-city",
     "position": 120,
-    "is_updated": true,
-    "source": "comicskingdom"
+    "is_updated": true
+  },
+  {
+    "name": "Edge City Classic",
+    "author": "Terry and Patty LaBan",
+    "url": "https://comicskingdom.com/edge-city",
+    "slug": "edge-city-classic",
+    "source": "comicskingdom",
+    "source_slug": "edge-city",
+    "position": 120,
+    "is_updated": true
   },
   {
     "name": "Eek!",
@@ -1874,14 +1882,6 @@
     "is_updated": true
   },
   {
-    "name": "Lunarbaboon",
-    "author": "Christopher Grady",
-    "url": "https://www.gocomics.com/lunarbaboon",
-    "slug": "lunarbaboon",
-    "position": 237,
-    "is_updated": false
-  },
-  {
     "name": "Maintaining",
     "author": "Nate Creekmore",
     "url": "https://www.gocomics.com/maintaining",
@@ -2399,8 +2399,7 @@
     "url": "https://www.gocomics.com/pluggers",
     "slug": "pluggers",
     "position": 302,
-    "is_updated": true,
-    "source": "comicskingdom"
+    "is_updated": true
   },
   {
     "name": "Pooch Cafe",
@@ -2648,8 +2647,7 @@
     "url": "https://www.gocomics.com/shoe",
     "slug": "shoe",
     "position": 333,
-    "is_updated": true,
-    "source": "comicskingdom"
+    "is_updated": true
   },
   {
     "name": "Sketchshark Comics",
@@ -2998,7 +2996,7 @@
   {
     "name": "Wannabe",
     "author": "Luca Debus",
-    "url": "https://www.gocomics.com/wannabe",
+    "url": "https://comicskingdom.com/wannabe",
     "slug": "wannabe",
     "position": 377,
     "is_updated": true,

--- a/scripts/check_scrape_counts.py
+++ b/scripts/check_scrape_counts.py
@@ -34,10 +34,13 @@ SOURCE_RULES = {
     # floor sits far below the range and only catches a real collapse.
     "comics":        {"payload": None,       "minimum": 100,
                       "note": "GoComics"},
-    # Fixed catalog: exactly 153 every day for 14 days. A partial scrape is
-    # therefore detectable with a tight floor.
+    # Fixed catalog, so a partial scrape is detectable with a tight floor.
+    # Was exactly 153/day; became 150 on 2026-08-24 when broomhilda, edge-city,
+    # pluggers and shoe moved to GoComics (they were mis-stamped as Comics
+    # Kingdom in 2025 and both sources were writing the same feed file) and
+    # edge-city-classic was added for CK's separate run of Edge City.
     "comicskingdom": {"payload": None,       "minimum": 140,
-                      "note": "Comics Kingdom (catalog of 153)"},
+                      "note": "Comics Kingdom (catalog of 150)"},
     # Genuinely variable 0-7 -- depends what publishers posted. `> 0` is the
     # only assertion the data supports, and it is exactly what 2026-08-03
     # needed.

--- a/scripts/comicskingdom_scraper_individual.py
+++ b/scripts/comicskingdom_scraper_individual.py
@@ -313,8 +313,14 @@ def load_comics_catalog():
     return ck_comics
 
 
-def scrape_comic_page(driver, comic_slug, date_str, debug=False):
-    """Scrape a single comic page."""
+def scrape_comic_page(driver, comic_slug, date_str, debug=False, feed_slug=None):
+    """Scrape a single comic page.
+
+    ``comic_slug`` is the identifier Comics Kingdom serves the strip under;
+    ``feed_slug`` is the identifier ComicCaster files it under. They differ only
+    when two sources run the same comic and each run needs its own feed -- see
+    the `source_slug` note in scrape_all_comics.
+    """
     global _SCRAPE_CALL_COUNT
     _SCRAPE_CALL_COUNT += 1
     url = f"https://comicskingdom.com/{comic_slug}/{date_str}"
@@ -391,7 +397,7 @@ def scrape_comic_page(driver, comic_slug, date_str, debug=False):
         
         comic_data = {
             'name': comic_name,
-            'slug': comic_slug,
+            'slug': feed_slug or comic_slug,
             'date': date_str,
             'url': url,
             'source': 'comicskingdom'
@@ -420,9 +426,16 @@ def scrape_all_comics(driver, comics, date_str):
     
     for i, comic in enumerate(comics, 1):
         slug = comic['slug']
+        # `source_slug` is the path Comics Kingdom serves this comic at, when it
+        # differs from the slug we file the feed under. Needed when GoComics and
+        # Comics Kingdom run the same comic at different points in its history:
+        # each run is a distinct work and needs its own feed, but upstream still
+        # only knows the one path. Defaults to slug, so 152 of 153 entries are
+        # unaffected.
+        source_slug = comic.get('source_slug') or slug
         print(f"[{i}/{len(comics)}] Scraping {comic['name']} ({slug})...")
-        
-        comic_data = scrape_comic_page(driver, slug, date_str, debug=False)
+
+        comic_data = scrape_comic_page(driver, source_slug, date_str, debug=False, feed_slug=slug)
         
         if comic_data:
             results.append(comic_data)

--- a/scripts/generate_comicskingdom_feeds.py
+++ b/scripts/generate_comicskingdom_feeds.py
@@ -27,7 +27,13 @@ from comiccaster.feed_generator import ComicFeedGenerator
 def extract_live_comicskingdom_entries(comic_info: Dict, limit: int = 30) -> List[Dict]:
     """Fetch live entries for a Comics Kingdom comic from page bootstrap JSON."""
     slug = comic_info['slug']
-    base_path = f"/vintage/{slug}" if comic_info.get('source_variant') == 'vintage' else f"/{slug}"
+    # Upstream path may differ from the feed slug -- see `source_slug` in
+    # scripts/comicskingdom_scraper_individual.py.
+    source_slug = comic_info.get('source_slug') or slug
+    base_path = (
+        f"/vintage/{source_slug}" if comic_info.get('source_variant') == 'vintage'
+        else f"/{source_slug}"
+    )
     url = f"https://comicskingdom.com{base_path}"
 
     try:

--- a/scripts/generate_gocomics_feeds.py
+++ b/scripts/generate_gocomics_feeds.py
@@ -97,6 +97,23 @@ def load_scraped_data(days_back: int = 90) -> Dict[str, List[Dict]]:
     return indexed
 
 
+# A GoComics comic is marked by the ABSENCE of a `source` key -- that is how the
+# catalog has always identified them, and 463 entries depend on it. Every other
+# source stamps its own name.
+#
+# This matters because both generators write public/feeds/<slug>.xml. When a
+# slug is claimed by another source and this generator writes it anyway, the two
+# take turns clobbering each other: pass 1 ends with Comics Kingdom, pass 2 runs
+# GoComics alone, so the feed alternated source twice a day and subscribers got
+# every strip twice. See tests/test_catalog_source_integrity.py.
+GOCOMICS_SOURCES = {None, "", "gocomics"}
+
+
+def owned_by_gocomics(comic: Dict) -> bool:
+    """True when the catalog assigns this comic to GoComics (or to no source)."""
+    return comic.get("source") in GOCOMICS_SOURCES
+
+
 def load_comics_catalog() -> List[Dict]:
     """Load the full GoComics catalog (regular + political comics)."""
     comics = []
@@ -203,10 +220,17 @@ def main():
         output_dir="public/feeds",
     )
 
+    # Only write feeds for comics GoComics actually owns. Skipping the rest is
+    # what keeps another source's feed from being overwritten on this pass.
+    owned = [comic for comic in catalog if owned_by_gocomics(comic)]
+    foreign = len(catalog) - len(owned)
+    if foreign:
+        logger.info(f"Skipping {foreign} comics owned by another source")
+
     successful = 0
     skipped = 0
 
-    for comic in catalog:
+    for comic in owned:
         if generate_feed_for_comic(comic, scraped_data, generator):
             successful += 1
         else:
@@ -216,7 +240,7 @@ def main():
     logger.info("GoComics Feed Generation Complete")
     logger.info(f"  Updated: {successful}")
     logger.info(f"  Skipped (no data): {skipped}")
-    logger.info(f"  Total catalog: {len(catalog)}")
+    logger.info(f"  GoComics-owned: {len(owned)} of {len(catalog)} catalog entries")
     logger.info("=" * 60)
 
     return 0

--- a/tests/test_catalog_source_integrity.py
+++ b/tests/test_catalog_source_integrity.py
@@ -1,0 +1,136 @@
+"""Catalog integrity: one comic, one source, one feed file.
+
+Every self-hosted feed lives at ``public/feeds/<slug>.xml`` (CONCEPTS.md,
+"Self-hosted-feed source"), and each comic carries a single ``source`` tag that
+selects how it is fetched. Those two facts together mean a slug may be claimed
+by at most one feed-generating source -- otherwise two generators write the same
+path and the last one to run silently wins.
+
+That is not hypothetical. ``shoe``, ``broomhilda``, ``edge-city`` and
+``pluggers`` were scraped by both GoComics and Comics Kingdom, so Pass 1 (which
+ends with Comics Kingdom) and Pass 2 (which runs GoComics alone) overwrote each
+other every single day, and subscribers received each strip twice from
+alternating sources.
+
+The root cause was a catalog edit, not scraper logic: commit 11e401b688
+("Add all Comics Kingdom comics", 2025-11-15) stamped ``source: comicskingdom``
+onto entries that already existed as GoComics comics and left their ``url``
+pointing at gocomics.com. These tests encode the invariant that edit broke.
+"""
+
+import json
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent
+PUBLIC = PROJECT_ROOT / "public"
+
+CATALOG_FILES = [
+    "comics_list.json",
+    "political_comics_list.json",
+    "spanish_comics_list.json",
+    "tinyview_comics_list.json",
+    "farside_comics_list.json",
+    "newyorker_comics_list.json",
+    "external_comics_list.json",
+]
+
+# A comic with no `source` is a GoComics comic -- that is how the catalog has
+# always marked them, and 463 entries rely on it.
+GOCOMICS = "gocomics"
+
+# The host a source's `url` must point at. An entry whose source and url
+# disagree is the exact fingerprint of the 2025-11-15 bulk stamp.
+SOURCE_HOST = {
+    GOCOMICS: "gocomics.com",
+    "comicskingdom": "comicskingdom.com",
+    "creators": "creators.com",
+    "tinyview": "tinyview.com",
+    "newyorker": "newyorker.com",
+    "farside-daily": "thefarside.com",
+    "farside-new": "thefarside.com",
+    "mrboffo": "mrboffocomics.com",
+}
+
+# External-RSS sources are exempt from both checks: ComicCaster generates no
+# feed for them (so they cannot collide on a feed path) and their url points at
+# the publisher's own site by definition.
+EXTERNAL = "external-rss"
+
+
+def _entries():
+    """Yield (catalog_filename, comic_dict) for every catalog entry."""
+    for name in CATALOG_FILES:
+        path = PUBLIC / name
+        if not path.exists():
+            continue
+        for comic in json.loads(path.read_text()):
+            if isinstance(comic, dict) and comic.get("slug"):
+                yield name, comic
+
+
+def _source_of(comic):
+    return comic.get("source") or GOCOMICS
+
+
+def test_every_catalog_entry_declares_a_known_source():
+    """An unrecognised source has no generator and no host mapping."""
+    known = set(SOURCE_HOST) | {EXTERNAL}
+    unknown = {
+        (name, comic["slug"], _source_of(comic))
+        for name, comic in _entries()
+        if _source_of(comic) not in known
+    }
+    assert not unknown, f"Catalog entries with an unknown source: {sorted(unknown)}"
+
+
+def test_source_and_url_agree():
+    """A comic's `url` must point at the host its `source` names.
+
+    This is the check that would have caught commit 11e401b688 the day it
+    landed: it stamped source=comicskingdom onto entries whose url still read
+    https://www.gocomics.com/..., and nothing objected for nine months.
+    """
+    mismatches = []
+    for name, comic in _entries():
+        source = _source_of(comic)
+        if source == EXTERNAL:
+            continue
+        expected = SOURCE_HOST[source]
+        host = (urlparse(comic.get("url") or "").netloc or "").lower()
+        host = host[4:] if host.startswith("www.") else host
+        if host and host != expected:
+            mismatches.append(f"{name}:{comic['slug']} source={source} url-host={host} (want {expected})")
+    assert not mismatches, (
+        "Catalog entries whose source and url disagree -- one of them is wrong, "
+        "and whichever it is, the comic is being fetched or linked from the "
+        "wrong place:\n  " + "\n  ".join(sorted(mismatches))
+    )
+
+
+def test_no_slug_is_claimed_by_two_feed_generating_sources():
+    """Two generators must never be able to write the same feed file.
+
+    Only feed-generating sources count: external-rss produces no
+    public/feeds/<slug>.xml, so an overlap with it cannot clobber anything.
+    """
+    owners = {}
+    for name, comic in _entries():
+        source = _source_of(comic)
+        if source == EXTERNAL:
+            continue
+        owners.setdefault(comic["slug"], {}).setdefault(source, set()).add(name)
+
+    contested = {
+        slug: {src: sorted(files) for src, files in by_source.items()}
+        for slug, by_source in owners.items()
+        if len(by_source) > 1
+    }
+    assert not contested, (
+        "Slugs claimed by more than one feed-generating source. Both generators "
+        "write public/feeds/<slug>.xml, so whichever runs last wins and the feed "
+        "flips source between passes:\n  "
+        + "\n  ".join(f"{slug}: {claims}" for slug, claims in sorted(contested.items()))
+    )

--- a/tests/test_comicskingdom_scraper.py
+++ b/tests/test_comicskingdom_scraper.py
@@ -651,3 +651,55 @@ class TestAuthRetry:
         assert rc == 0
         assert auth_calls == 1
         assert len(made) == 1, "a healthy run must not launch a second browser"
+
+
+class TestSourceSlugSeparation:
+    """A comic's upstream path and its feed identity are separate things.
+
+    GoComics and Comics Kingdom both run Edge City, but at different points in
+    its history -- GoComics the 2011 sequence, Comics Kingdom the 2006 one.
+    Those are two distinct works, so each needs its own feed file, but Comics
+    Kingdom still only serves one path (/edge-city). `source_slug` carries the
+    upstream path while `slug` stays the feed identity.
+    """
+
+    def _soup_driver(self, html):
+        driver = MagicMock()
+        driver.page_source = html
+        driver.current_url = "https://comicskingdom.com/edge-city/2026-08-24"
+        return driver
+
+    def test_scrape_uses_source_slug_for_the_url_and_slug_for_the_record(self):
+        """Fetch /edge-city, but file the result under edge-city-classic."""
+        driver = self._soup_driver("<html><title>Edge City Comic Strip | Comics Kingdom</title></html>")
+
+        with patch.object(cki, 'scrape_comic_page', wraps=cki.scrape_comic_page) as spy:
+            with patch.object(cki, 'time') as _t:
+                _t.sleep = lambda *_: None
+                cki.scrape_all_comics(
+                    driver,
+                    [{'name': 'Edge City Classic', 'slug': 'edge-city-classic',
+                      'source_slug': 'edge-city'}],
+                    '2026-08-24',
+                )
+
+        assert spy.call_count == 1
+        args, kwargs = spy.call_args
+        assert args[1] == 'edge-city', (
+            "Scraper must request the upstream path from source_slug; "
+            f"requested {args[1]!r} instead."
+        )
+        assert kwargs.get('feed_slug') == 'edge-city-classic'
+
+    def test_source_slug_defaults_to_slug(self):
+        """Entries without source_slug are untouched -- 152 of 153 CK comics."""
+        driver = self._soup_driver("<html><title>Blondie | Comics Kingdom</title></html>")
+
+        with patch.object(cki, 'scrape_comic_page', wraps=cki.scrape_comic_page) as spy:
+            with patch.object(cki, 'time') as _t:
+                _t.sleep = lambda *_: None
+                cki.scrape_all_comics(driver, [{'name': 'Blondie', 'slug': 'blondie'}], '2026-08-24')
+
+        args, kwargs = spy.call_args
+        assert args[1] == 'blondie'
+        assert kwargs.get('feed_slug') == 'blondie'

--- a/tests/test_generate_gocomics_feeds.py
+++ b/tests/test_generate_gocomics_feeds.py
@@ -406,3 +406,67 @@ class TestCatalogPath:
                 f"the generator. This indicates the generator is reading a stale "
                 f"catalog copy instead of public/."
             )
+
+
+class TestSourceOwnership:
+    """The generator must not write feeds for comics another source owns.
+
+    Both generate_gocomics_feeds.py and generate_comicskingdom_feeds.py write
+    public/feeds/<slug>.xml. generate_comicskingdom_feeds.py has always filtered
+    on `source == 'comicskingdom'`; this generator did not filter at all, so any
+    slug claimed by both sources flipped between them -- Comics Kingdom last in
+    pass 1, GoComics alone in pass 2. See
+    tests/test_catalog_source_integrity.py for the catalog-side invariant.
+    """
+
+    def test_absent_source_is_gocomics_owned(self):
+        """The catalog marks GoComics comics by omitting `source`."""
+        from scripts.generate_gocomics_feeds import owned_by_gocomics
+
+        assert owned_by_gocomics({'slug': 'garfield'})
+        assert owned_by_gocomics({'slug': 'garfield', 'source': None})
+        assert owned_by_gocomics({'slug': 'garfield', 'source': ''})
+        assert owned_by_gocomics({'slug': 'garfield', 'source': 'gocomics'})
+
+    def test_another_sources_comic_is_not_owned(self):
+        from scripts.generate_gocomics_feeds import owned_by_gocomics
+
+        assert not owned_by_gocomics({'slug': 'shoe', 'source': 'comicskingdom'})
+        assert not owned_by_gocomics({'slug': 'lunarbaboon', 'source': 'tinyview'})
+        assert not owned_by_gocomics({'slug': 'archie', 'source': 'creators'})
+
+    @patch('scripts.generate_gocomics_feeds.ComicFeedGenerator')
+    @patch('scripts.generate_gocomics_feeds.load_comics_catalog')
+    @patch('scripts.generate_gocomics_feeds.load_scraped_data')
+    def test_main_skips_foreign_source_comics(
+        self, mock_load_data, mock_load_catalog, mock_generator_cls
+    ):
+        """A comic owned by Comics Kingdom gets no feed written here.
+
+        Both comics have scraped data, so the only thing that can exclude the
+        Comics Kingdom one is the ownership filter.
+        """
+        mock_load_data.return_value = {
+            'garfield': [{'slug': 'garfield', 'date': '2026-08-24',
+                          'image_url': 'https://example.com/g.jpg',
+                          'url': 'https://www.gocomics.com/garfield/2026/08/24'}],
+            'shoe': [{'slug': 'shoe', 'date': '2026-08-24',
+                      'image_url': 'https://example.com/s.jpg',
+                      'url': 'https://www.gocomics.com/shoe/2026/08/24'}],
+        }
+        mock_load_catalog.return_value = [
+            {'name': 'Garfield', 'slug': 'garfield'},
+            {'name': 'Shoe', 'slug': 'shoe', 'source': 'comicskingdom'},
+        ]
+        generator = MagicMock()
+        generator.generate_feed.return_value = True
+        mock_generator_cls.return_value = generator
+
+        assert main() == 0
+
+        generated = [c.args[0]['slug'] for c in generator.generate_feed.call_args_list]
+        assert 'garfield' in generated
+        assert 'shoe' not in generated, (
+            "Wrote a feed for a Comics Kingdom comic -- generate_comicskingdom_feeds.py "
+            "writes the same path, so the two would overwrite each other every day."
+        )


### PR DESCRIPTION
Fixes the bug behind "Edge City shows me two different storylines every day."

## What was happening

Four slugs — `broomhilda`, `edge-city`, `pluggers`, `shoe` — were scraped by **both** GoComics and Comics Kingdom. Both generators write `public/feeds/<slug>.xml`, so they overwrote each other every day:

- **Pass 1 (03:05)** runs GoComics then Comics Kingdom → CK wins
- **Pass 2 (13:00)** runs GoComics **alone** → GoComics wins, and CK never runs to reclaim it

Git history shows the perfect alternation:

```
08-24 03:21  comicskingdom.com
08-23 13:02  www.gocomics.com
08-23 03:20  comicskingdom.com
08-22 13:02  www.gocomics.com
```

`<guid>` changes with the source, so readers saw each flip as new items — **every strip delivered twice a day.** Nothing was ever logged: each run genuinely succeeded, it just wrote different contents than six hours earlier.

## Root cause (two layers)

1. **The catalog contradicted itself.** Commit `11e401b688` ("Add all Comics Kingdom comics", 2025-11-15) stamped `source: comicskingdom` onto entries that already existed as GoComics comics, leaving `url` on gocomics.com. That fingerprint — `source` and `url` naming different hosts — matched exactly **5 of 600+** entries.
2. **Only one generator enforced ownership.** `generate_comicskingdom_feeds.py` always filtered `source == 'comicskingdom'`. `generate_gocomics_feeds.py` filtered on **nothing**.

## Same strip, or different runs? They need different fixes

This was the crux, and eyeballing it wrong is easy:

| | Same strip | Different runs |
|---|---|---|
| comics | Broom Hilda, Pluggers, Shoe | Edge City |
| fix | pick one source | give each run its own slug |

Measured by perceptual correlation, with **Broom Hilda as a positive control**:

| | same-day r | best match at any offset |
|---|---|---|
| Broom Hilda (control) | **0.989–0.998**, offset 0 every day | 0.99 |
| Edge City | 0.03–0.20 | **0.33** (noise floor, ±16-day window) |

Copyright lines confirm why: **GoComics runs the 2011 sequence, Comics Kingdom the 2006 one.** Both reruns, different vintages — genuinely two works.

> ⚠️ The printed date in the art (`7.10` / `7.7`) is day-month only, so it cannot tell a 3-day lag from a 5-year-old rerun. Reading it that way gave me a confidently wrong first answer. The copyright year and image comparison are the real evidence.

## The changes

**Catalog** (`public/comics_list.json`):
- `broomhilda`, `pluggers`, `shoe` → GoComics. Content is identical, so the tiebreak was purely delivery reliability: **83/83 days** for GoComics vs **79–80/83** for CK (Jun–Aug), CK's misses matching its session-failure issues.
- `edge-city` → GoComics (keeps the existing feed URL, so current subscriptions survive); CK's run becomes **`edge-city-classic`**.
- `wannabe` → `url` corrected to comicskingdom.com.
- `lunarbaboon` → dropped a vestigial GoComics duplicate (`is_updated: false`, not carried once in 24 days; TinyView owns it).

**Code:**
- `owned_by_gocomics()` + a filter in `main()`. Deliberately **not** in `load_comics_catalog()` — an existing test asserts that loader returns every `public/` entry, guarding the 2026-05-16 dual-catalog fix, and it keeps its meaning.
- New optional **`source_slug`**: the path a source serves a comic at, when it differs from the slug we file it under (CK serves `/edge-city`; we file `edge-city-classic`). Defaults to `slug`, so 149 of 150 CK entries and every other source are untouched. This is the "canonical identifier vs local identity" split from the Spanish-contamination fix.
- `check_scrape_counts.py`: CK catalog is 150/day now, not 153. The 140 floor still holds.

## Verification

- `pytest`: **499 passed** (491 + 8 new)
- **End-to-end:** ran both generators in pass-1 order against real scraped data in a sandbox. All four feeds stayed on GoComics and `edge-city-classic` was produced from CK — where previously the second generator clobbered the first.
- Live-checked that `source_slug` makes the CK generator fetch `/edge-city` and return properly dated entries with images.

## Guard against regression

`tests/test_catalog_source_integrity.py` asserts: every entry declares a known source; `source` and `url` name the same host (**this would have caught `11e401b688` the day it landed**); and no slug is claimed by two feed-generating sources. All offline, all in the default suite.

## Notes for the operator

- No feed XML is committed here. `edge-city-classic.xml` appears on the next **Pass 1** (Pass 2 is GoComics-only, so it won't create it).
- The four existing feed files still contain historical entries from the alternating months. This stops new mixing; it does not rewrite that history.
- `edge-city-classic` needs a separate subscription to follow the 2006 run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FbzH95RUbguw6ZrVuCk3n