### PR TITLE
fix: present headless Chrome as regular Chrome so GoComics' bot shield admits it

### DIFF
--- a/comiccaster/webdriver_setup.py
+++ b/comiccaster/webdriver_setup.py
@@ -16,14 +16,53 @@ bump no longer requires manual intervention.
 exact binary wins. Useful if webdriver-manager itself ever fails (network
 hiccup, upstream outage) and we need to pin to a known-good driver
 quickly.
+
+It also presents headless sessions as regular Chrome. Headless Chrome
+announces itself as ``HeadlessChrome/<version>`` and CDN bot shields refuse
+that token outright: on 2026-09-05 GoComics' Bunny Shield challenge never
+cleared for it, while the same browser with the ``Headless`` prefix dropped
+cleared in under two seconds (issue #198). Only the token is changed -- the
+real Chrome version is kept, so the string stays truthful across updates.
 """
 
+import logging
 import os
 
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.chrome.service import Service
 from webdriver_manager.chrome import ChromeDriverManager
+
+logger = logging.getLogger(__name__)
+
+_HEADLESS_UA_TOKEN = 'HeadlessChrome/'
+
+
+def regular_chrome_user_agent(user_agent: str) -> str:
+    """Return ``user_agent`` with the headless marker dropped, version intact."""
+    return user_agent.replace(_HEADLESS_UA_TOKEN, 'Chrome/')
+
+
+def _present_as_regular_chrome(driver: webdriver.Chrome) -> None:
+    """Override a headless session's user-agent so it reads as regular Chrome.
+
+    No-op for headed sessions. A failure here is logged, not raised -- most
+    sources do not care, and the scrape should still be attempted.
+    """
+    try:
+        user_agent = driver.execute_script('return navigator.userAgent')
+        if _HEADLESS_UA_TOKEN not in user_agent:
+            return
+        driver.execute_cdp_cmd(
+            'Network.setUserAgentOverride',
+            {'userAgent': regular_chrome_user_agent(user_agent)},
+        )
+    except Exception as exc:  # noqa: BLE001 - never let this abort a scrape
+        logger.warning(
+            "Could not normalise the headless user-agent (%s); "
+            "bot-shielded sources such as GoComics may refuse this session",
+            exc,
+        )
 
 
 def build_chrome_driver(options: Options) -> webdriver.Chrome:
@@ -38,10 +77,13 @@ def build_chrome_driver(options: Options) -> webdriver.Chrome:
         options: Pre-configured ``selenium.webdriver.chrome.options.Options``.
 
     Returns:
-        An open ``webdriver.Chrome`` instance.
+        An open ``webdriver.Chrome`` instance. Headless sessions present a
+        regular Chrome user-agent (see module docstring).
     """
     if 'CHROMEDRIVER_PATH' in os.environ:
         service = Service(executable_path=os.environ['CHROMEDRIVER_PATH'])
     else:
         service = Service(ChromeDriverManager().install())
-    return webdriver.Chrome(service=service, options=options)
+    driver = webdriver.Chrome(service=service, options=options)
+    _present_as_regular_chrome(driver)
+    return driver

--- a/docs/solutions/best-practices/scrapers-must-use-build-chrome-driver.md
+++ b/docs/solutions/best-practices/scrapers-must-use-build-chrome-driver.md
@@ -83,3 +83,6 @@ recovered the gap.
 - Incident origin: `comiccaster/webdriver_setup.py` module docstring.
 - `docs/solutions/logic-errors/comicskingdom-hang-diagnosis.md` — the
   persistent-profile (Shape A) pattern that TinyView already uses for auth.
+- `docs/solutions/logic-errors/gocomics-bunny-shield-refuses-headless-chrome.md` —
+  the builder also presents headless sessions as regular Chrome; a scraper that
+  bypasses it is refused by bot-shielded sources (GoComics, 2026-09-05).

--- a/docs/solutions/logic-errors/gocomics-bunny-shield-refuses-headless-chrome.md
+++ b/docs/solutions/logic-errors/gocomics-bunny-shield-refuses-headless-chrome.md
@@ -1,0 +1,114 @@
+---
+title: GoComics' Bunny Shield refuses HeadlessChrome — every favorites page came back as a challenge interstitial
+date: 2026-09-05
+category: logic-errors
+module: scrapers
+problem_type: external-site-change
+component: authenticated_scraper_secure.py / comiccaster/webdriver_setup.py
+severity: high
+applies_when:
+  - "GoComics scrape logs 'Login successful' then 'No comic containers found' on every custom page"
+  - "/tmp/gocomics_debug_<date>.html is titled 'Establishing a secure connection ...'"
+  - "A curl of any gocomics.com strip page returns HTTP 403 with 'cdn-challenge: true'"
+  - "Any other source starts returning a bunny.net / '.bunny-shield' interstitial"
+tags: [gocomics, bot-challenge, bunny-shield, headless, user-agent, selenium, webdriver_setup]
+stack: [python, selenium]
+github_issues: [198]
+---
+
+## TL;DR
+
+Between the 2026-09-04 13:00 Pass 2 and the 2026-09-05 03:05 Pass 1, GoComics put
+a **Bunny Shield** (bunny.net CDN) bot challenge in front of its strip and profile
+pages. The challenge is a JavaScript proof-of-work interstitial titled
+*"Establishing a secure connection ..."*. It **never clears for a browser whose
+user-agent contains `HeadlessChrome/`**; the identical browser presenting
+`Chrome/<same version>` clears it in under two seconds.
+
+The fix lives in the shared driver builder: `build_chrome_driver()` now reads the
+session's user-agent and, if it carries the headless token, overrides it via
+Chrome DevTools (`Network.setUserAgentOverride`) with the same string minus
+`Headless`. Real version kept, nothing else touched, headed sessions untouched.
+
+## What the failure looked like
+
+```
+[1/7] Scraping GoComics (authenticated)...
+✅ Login successful
+Scraping: https://www.gocomics.com/profile/User52732/comics/221821
+  ⚠️  No comic containers found. Page source saved to /tmp/gocomics_debug_2026-09-05.html
+  Extracted 0 comics
+  ... (same for all six pages)
+✅ SUCCESS! Extracted 0 comics for 2026-09-05
+```
+
+The scraper's own exit was success. The invariant guard's *count* half caught it
+(`GoComics: only 0 entries, expected at least 100`) and opened issue #198 — the
+existence-only guard of before 2026-08-05 would have shipped an empty day as
+ALL SUCCESS (see `silent-empty-scrape-passed-as-success.md`). Published feeds
+were not damaged; the generator kept history and simply added nothing.
+
+Login succeeded because the OAuth flow runs on Microsoft's B2C domain, which is
+not behind the shield. Only `www.gocomics.com` pages are gated — and the homepage
+is not, which is why a quick "is GoComics up?" check would have said yes.
+
+## How it was diagnosed
+
+1. `/tmp/gocomics_debug_2026-09-05.html` was 2 KB of challenge page, not a
+   profile page: `<title>Establishing a secure connection ...</title>`, assets
+   under `/.bunny-shield/`, an iframe on `shield-templates-prod.b-cdn.net`, a
+   footer stuck at `Submitting...`.
+2. `curl -I https://www.gocomics.com/garfield` → `403`, `server: BunnyCDN`,
+   `cdn-challenge: true`. So it is the CDN, not a page-structure change.
+3. A probe with the scraper's exact Chrome options, polling `driver.title`:
+
+   | Mode | User-agent | Result |
+   |---|---|---|
+   | `--headless=new` | `HeadlessChrome/152` (default) | stuck at "Submitting..." for 90 s |
+   | headed | `Chrome/152`, `navigator.webdriver` still `true` | clears in 1.7 s |
+   | `--headless=new` + UA override | `Chrome/152` | clears in 1.7 s |
+
+   Headed passing *with* the webdriver flag set is the key measurement: the shield
+   was keying on the literal `HeadlessChrome` token, nothing more.
+4. Ran the real scraper against a scratch `--output-dir` with the fix: 231 comics
+   across all six pages.
+
+## The fix
+
+`comiccaster/webdriver_setup.py`:
+
+- `regular_chrome_user_agent(ua)` — drops `HeadlessChrome/` → `Chrome/`, keeps the
+  version.
+- `build_chrome_driver()` calls `_present_as_regular_chrome(driver)` after
+  construction. It reads `navigator.userAgent`; if the token is present it
+  applies `Network.setUserAgentOverride` for the session. The override persists
+  across navigations. A failure is logged as a warning, never raised — most
+  sources do not care and the scrape should still run.
+
+Because every scraper goes through `build_chrome_driver` (see
+`best-practices/scrapers-must-use-build-chrome-driver.md`), Comics Kingdom,
+TinyView and Far Side get the same treatment for free if their CDNs follow suit.
+
+`scripts/authenticated_scraper_secure.py`:
+
+- `is_bot_challenge_page(html)` recognises the interstitial, and the
+  "No comic containers found" branch now says so explicitly and points here.
+  The old message is kept so existing log greps still work.
+
+Why a DevTools override rather than `--user-agent=...` on the command line: the
+flag needs the Chrome version *before* launch (and the version bumps itself —
+see `chrome-autoupdate-breaks-first-ck-launch.md`). Reading the browser's own
+string after launch and editing one token is always accurate.
+
+## If it happens again
+
+- **Same symptom, headless still refused after this fix:** Bunny has tightened
+  detection beyond the UA token. Run the GoComics scraper headed
+  (`--show-browser`) — the measured fallback, and the host already has a GUI
+  login and runs Comics Kingdom headed via `CK_SCRAPER_EXTRA_ARGS`. Re-measure
+  before assuming; the probe is three navigations.
+- **Different source, same interstitial:** the fix is already in the shared
+  builder. Check that scraper actually uses `build_chrome_driver`.
+- **Recovery:** land the fix before the next pass. Pass 2 (13:00) runs
+  `--merge` and fills the day's file; its success dispatch closes the issue.
+  No manual feed surgery needed.

--- a/scripts/authenticated_scraper_secure.py
+++ b/scripts/authenticated_scraper_secure.py
@@ -26,6 +26,10 @@ import time
 # CSS class patterns used to locate elements on profile pages.
 _COMIC_CONTAINER_SELECTOR = '[class*="ComicViewer"]'
 _COMIC_CONTAINER_RE = re.compile(r'ComicViewer')
+
+# Markers of the Bunny Shield interstitial GoComics' CDN serves instead of the
+# page when it decides the client is a bot (first seen 2026-09-05, issue #198).
+_BOT_CHALLENGE_MARKERS = ('Establishing a secure connection', '/.bunny-shield/')
 _NOT_ISSUED_RE = re.compile(r'FeaturesNotIssued')
 
 
@@ -209,6 +213,11 @@ def _get_badge_name(img):
     return None
 
 
+def is_bot_challenge_page(html):
+    """True when ``html`` is the CDN's bot-challenge interstitial, not GoComics content."""
+    return any(marker in html for marker in _BOT_CHALLENGE_MARKERS)
+
+
 def extract_comics_from_page(driver, page_url, date_str):
     """Extract comics from a custom/profile page.
 
@@ -240,6 +249,10 @@ def extract_comics_from_page(driver, page_url, date_str):
     if not containers:
         debug_file = Path(f'/tmp/gocomics_debug_{date_str}.html')
         debug_file.write_text(driver.page_source)
+        if is_bot_challenge_page(driver.page_source):
+            print("  ❌ Page is a CDN bot challenge (Bunny Shield), not GoComics content. "
+                  "The browser was refused before reaching the page -- see "
+                  "docs/solutions/logic-errors/gocomics-bunny-shield-refuses-headless-chrome.md")
         print(f"  ⚠️  No comic containers found. Page source saved to {debug_file}")
     comics = []
     no_link_count = 0

--- a/tests/test_authenticated_scraper.py
+++ b/tests/test_authenticated_scraper.py
@@ -19,6 +19,7 @@ from scripts.authenticated_scraper_secure import (
     page_url_for_date,
     backfill_target_dates,
     run_backfill,
+    is_bot_challenge_page,
 )
 from datetime import date
 
@@ -520,3 +521,39 @@ class TestMergeWithExisting:
 
         slugs = {c.get('slug') for c in result}
         assert slugs == {'chipbok', 'nickanderson'}
+
+
+_BUNNY_SHIELD_HTML = """<html><head>
+    <title>Establishing a secure connection ...</title>
+    <link href="/.bunny-shield/assets/challenge-styles.css" rel="stylesheet">
+    <script src="/.bunny-shield/assets/shield-challenge.js"></script>
+</head>
+<body data-pow="abc#def#1788599274#ghi">
+    <iframe src="https://shield-templates-prod.b-cdn.net/33498/challenge.html"></iframe>
+    <div class="challenge-footer"><div class="status">Submitting...</div></div>
+</body></html>"""
+
+
+class TestBotChallengeDetection:
+    """A CDN bot-challenge interstitial must be named as such, not reported
+    as a page with no comics (2026-09-05, issue #198)."""
+
+    def test_bunny_shield_page_is_a_challenge(self):
+        assert is_bot_challenge_page(_BUNNY_SHIELD_HTML)
+
+    def test_profile_page_is_not_a_challenge(self):
+        html = _build_page_html(_make_comic_container('garfield', 'Garfield', 'img001'))
+        assert not is_bot_challenge_page(html)
+
+    def test_empty_profile_page_is_not_a_challenge(self):
+        assert not is_bot_challenge_page(_build_page_html(''))
+
+    def test_extract_names_the_challenge_and_returns_nothing(self, capsys):
+        driver = _mock_driver(_BUNNY_SHIELD_HTML)
+
+        comics = extract_comics_from_page(driver, 'https://example.com/page', '2026-09-05')
+
+        assert comics == []
+        out = capsys.readouterr().out
+        assert 'bot challenge' in out.lower()
+        assert 'No comic containers found' in out

--- a/tests/test_webdriver_setup.py
+++ b/tests/test_webdriver_setup.py
@@ -1,0 +1,68 @@
+"""Tests for the shared Chrome driver builder in ``comiccaster.webdriver_setup``.
+
+Headless Chrome announces itself as ``HeadlessChrome/<version>``. On
+2026-09-05 GoComics put a Bunny Shield bot challenge in front of its pages
+that never clears for that token, while the identical browser passing a
+plain ``Chrome/<version>`` user-agent clears it in under two seconds. The
+builder therefore presents headless sessions as regular Chrome, keeping the
+real version so the string stays truthful across Chrome updates.
+"""
+
+from unittest.mock import patch
+
+from selenium.webdriver.chrome.options import Options
+
+from comiccaster import webdriver_setup
+from comiccaster.webdriver_setup import build_chrome_driver, regular_chrome_user_agent
+
+HEADLESS_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36"
+)
+REGULAR_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36"
+)
+
+
+class TestRegularChromeUserAgent:
+    def test_drops_headless_token_but_keeps_version(self):
+        assert regular_chrome_user_agent(HEADLESS_UA) == REGULAR_UA
+
+    def test_regular_user_agent_is_unchanged(self):
+        assert regular_chrome_user_agent(REGULAR_UA) == REGULAR_UA
+
+
+def _build_with_reported_ua(reported_ua, cdp_side_effect=None):
+    """Build a driver with Chrome and ChromeDriverManager mocked out."""
+    with patch.object(webdriver_setup, "ChromeDriverManager") as manager, \
+            patch.object(webdriver_setup.webdriver, "Chrome") as chrome:
+        manager.return_value.install.return_value = "/fake/chromedriver"
+        driver = chrome.return_value
+        driver.execute_script.return_value = reported_ua
+        if cdp_side_effect is not None:
+            driver.execute_cdp_cmd.side_effect = cdp_side_effect
+        result = build_chrome_driver(Options())
+    return result
+
+
+class TestBuildChromeDriverUserAgent:
+    def test_headless_session_presents_as_regular_chrome(self):
+        driver = _build_with_reported_ua(HEADLESS_UA)
+
+        driver.execute_cdp_cmd.assert_called_once_with(
+            "Network.setUserAgentOverride", {"userAgent": REGULAR_UA}
+        )
+
+    def test_headed_session_is_left_alone(self):
+        driver = _build_with_reported_ua(REGULAR_UA)
+
+        driver.execute_cdp_cmd.assert_not_called()
+
+    def test_override_failure_still_returns_driver(self, caplog):
+        driver = _build_with_reported_ua(
+            HEADLESS_UA, cdp_side_effect=RuntimeError("CDP unavailable")
+        )
+
+        assert driver is not None
+        assert "user-agent" in caplog.text.lower()


### PR DESCRIPTION
## Summary

Closes #198.

Overnight on 2026-09-05 GoComics put a **Bunny Shield** (bunny.net) bot challenge in front of its strip and profile pages. The challenge is a JS proof-of-work interstitial titled *"Establishing a secure connection ..."* and it never clears for a browser whose user-agent contains `HeadlessChrome/`. Login still succeeded (the OAuth flow is on Microsoft's domain, not behind the shield), so all six favorites pages returned 0 containers, the scraper wrote `[]`, and the invariant guard caught it.

## Measurements

Probe with the scraper's exact Chrome options, polling the page title:

| Mode | User-agent | Result |
|---|---|---|
| `--headless=new` | `HeadlessChrome/152` (default) | stuck at "Submitting..." for 90 s |
| headed | `Chrome/152`, `navigator.webdriver` still `true` | clears in 1.7 s |
| `--headless=new` + UA override | `Chrome/152` | clears in 1.7 s |

The shield keys on the literal `HeadlessChrome` token only.

## Change

- `comiccaster/webdriver_setup.py`: `build_chrome_driver()` reads the session's user-agent after launch and, if it carries the headless token, overrides it via DevTools (`Network.setUserAgentOverride`) with the same string minus `Headless`. The real Chrome version is kept, so it stays truthful across auto-updates. Headed sessions are untouched. Failure to override logs a warning and never aborts the scrape. Every Selenium scraper goes through this builder, so the others inherit it if their CDNs follow suit.
- `scripts/authenticated_scraper_secure.py`: `is_bot_challenge_page()` names the interstitial in the log instead of "no comic containers".
- Tests: new `tests/test_webdriver_setup.py`; challenge-detection tests added to `tests/test_authenticated_scraper.py`.
- Docs: `docs/solutions/logic-errors/gocomics-bunny-shield-refuses-headless-chrome.md`, plus a cross-reference from the build-chrome-driver best-practice doc.

## Verification

- `pytest -v`: 508 passed.
- Real scrape with the fix against the live site to a scratch `--output-dir`: **231 comics** across all six pages (0 in the failed run).

## Deploy note

Merge before **13:00 CDT today** and Pass 2 recovers on its own: it resets to `origin/main`, runs the GoComics scrape with `--merge`, regenerates feeds, and its success dispatch closes #198. If Bunny later tightens detection beyond the UA token, the measured fallback is running the GoComics scraper headed (`--show-browser`), as Comics Kingdom already does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wu9jQhU1YAmAjdo9J9aPW4
